### PR TITLE
remove: SetIsDrawCollisionArea メソッドを削除

### DIFF
--- a/app/src/entity/player/Player.h
+++ b/app/src/entity/player/Player.h
@@ -78,7 +78,6 @@ public: /// Getter
     Object3d* GetObject3d() const { return object_.get(); }
 
 public: /// Setter
-    void SetIsDrawCollisionArea(bool isDraw) { isDrawCollisionArea_ = isDraw; }
     void DisableMovement();
     void DisableInput();
 


### PR DESCRIPTION
### 変更内容

#### Player.h
- `SetIsDrawCollisionArea` メソッドを削除しました。
  - このメソッドは、`isDrawCollisionArea_` フラグを設定するセッター関数でした。
  - 削除により、`isDrawCollisionArea_` の設定がコード内で直接行われるか、もしくはこのフラグ自体が不要になった可能性があります。

#### その他
- 他のゲッター関数（`IsShot`, `IsSlow`, `GetObject3d`）には変更はありません。