### PR TITLE
feat: PlayerExplosionTriggerのスコア管理機能を追加

### DIFF
--- a/app/src/entity/player/Player.cpp
+++ b/app/src/entity/player/Player.cpp
@@ -90,6 +90,7 @@ void Player::Update()
     }
     emitterConstant_->Update();
 
+    pExplosionTrigger_->Update();
 
     /// 3dモデルの更新
     object_->SetTranslate(transform_.translate);
@@ -215,6 +216,8 @@ void Player::ImGui()
 #ifdef _DEBUG
     EntityBase::ImGui();
     ImGui::DragFloat("MovePower", &movePower_, 0.12f);
+
+    pExplosionTrigger_->ImGui();
 #endif
 }
 

--- a/app/src/entity/player/PlayerExplosionTrigger.cpp
+++ b/app/src/entity/player/PlayerExplosionTrigger.cpp
@@ -1,6 +1,9 @@
 #include "PlayerExplosionTrigger.h"
-#include <functional>
 
+#include <Features/Event/EventListener.h>
+#include <functional>
+#include <Features/DeltaTimeManager/DeltaTimeManager.h>
+#include <imgui.h>
 
 void PlayerExplosionTrigger::Initialize()
 {
@@ -11,9 +14,49 @@ void PlayerExplosionTrigger::Initialize()
             std::placeholders::_1
         )
     );
+
+    decreaseTimer_ = std::make_unique<TimeMeasurerByDt>();
 }
 
-void PlayerExplosionTrigger::OnKillEnemyEvent(const KillEnemyEvent& payload)
+void PlayerExplosionTrigger::Update()
+{
+    decreaseTimer_->Update(static_cast<uint32_t>(DeltaTimeChannelReserved::Game));
+
+    if (decreaseTimer_->GetNow<float>() > kDecreaseBeginTime)
+    {
+        DecreaseScore();
+    }
+}
+
+void PlayerExplosionTrigger::ImGui()
+{
+    #ifdef _DEBUG
+
+    ImGui::ProgressBar(currentScore_ / targetTriggerScore_);
+    ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+    ImGui::Text("Current Score");
+
+    float decreaseTimeFraction = decreaseTimer_->GetNow<float>() / kDecreaseBeginTime;
+    if (decreaseTimeFraction > 1.0f) decreaseTimeFraction = 1.0f;
+    ImGui::ProgressBar(decreaseTimeFraction);
+    ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+    ImGui::Text("Until Decrease");
+
+    #endif // _DEBUG
+}
+
+void PlayerExplosionTrigger::OnKillEnemyEvent([[maybe_unused]]const KillEnemyEvent& payload)
 {
     currentScore_ += kScorePerEnemy;
+    if (currentScore_ > targetTriggerScore_) currentScore_ = targetTriggerScore_;
+    decreaseTimer_->Reset();
+    decreaseTimer_->Start();
+}
+
+void PlayerExplosionTrigger::DecreaseScore()
+{
+    auto channel = static_cast<uint32_t>(DeltaTimeChannelReserved::Game);
+    float dt = DeltaTimeManager::GetInstance()->GetDeltaTime(channel);
+    currentScore_ -= kDecreasePerSec * dt;
+    if (currentScore_ < 0.0f) currentScore_ = 0.0f;
 }

--- a/app/src/entity/player/PlayerExplosionTrigger.h
+++ b/app/src/entity/player/PlayerExplosionTrigger.h
@@ -1,7 +1,9 @@
 #pragma once
-#include <Features/Event/EventListener.h>
 #include <logic/event/KillEnemyEvent.h>
+#include <Features/TimeMeasurer/TimeMeasurerByDt.h>
+#include <Features/Event/EventSubscription.h>
 #include <optional>
+#include <memory>
 
 class PlayerExplosionTrigger
 {
@@ -10,11 +12,20 @@ public:
     ~PlayerExplosionTrigger() = default;
 
     void Initialize();
+    void Update();
+    void ImGui();
     void OnKillEnemyEvent(const KillEnemyEvent& payload);
 
 private:
-    static constexpr float kScorePerEnemy = 10.0f;
-    std::optional<EventSubscription> subscription_;
+    void DecreaseScore();
+
+    static constexpr float kScorePerEnemy = 5.0f;
+    static constexpr float kDecreaseBeginTime = 1.0f;
+    static constexpr float kDecreasePerSec = 20.0f; // 20 points per second
+
     const float targetTriggerScore_ = 100.0f;
-    float currentScore_ = 0.0f;
+
+    std::unique_ptr<TimeMeasurerByDt>   decreaseTimer_ = {};
+    std::optional<EventSubscription>    subscription_ = std::nullopt;
+    float                               currentScore_ = 0.0f;
 };


### PR DESCRIPTION
### Player.cpp
- `Player::Update()` に `pExplosionTrigger_->Update();` を追加。
  - `PlayerExplosionTrigger` の更新処理を統合。
- `Player::ImGui()` に `pExplosionTrigger_->ImGui();` を追加。
  - デバッグ時に `PlayerExplosionTrigger` の状態を ImGui で確認可能に。

### PlayerExplosionTrigger.cpp
- `#include` に `DeltaTimeManager.h`、`imgui.h` を追加。
- `PlayerExplosionTrigger::Initialize()`:
  - `decreaseTimer_` を初期化。
- 新規関数 `PlayerExplosionTrigger::Update()` を追加。
  - スコア減少のタイミングを管理。
- 新規関数 `PlayerExplosionTrigger::ImGui()` を追加。
  - デバッグ時にスコアや減少タイマーの状態を可視化。
- `PlayerExplosionTrigger::OnKillEnemyEvent()`:
  - スコア増加処理を変更し、`targetTriggerScore_` を超えないよう制限。
  - スコア増加時にタイマーをリセット・再スタート。
- 新規関数 `PlayerExplosionTrigger::DecreaseScore()` を追加。
  - 時間経過に応じたスコア減少処理を実装。

### PlayerExplosionTrigger.h
- `#include` に `TimeMeasurerByDt.h`、`memory` を追加。
- 新規メンバ関数 `Update()`、`ImGui()`、`DecreaseScore()` を追加。
- 定数 `kScorePerEnemy` を 10.0f から 5.0f に変更。
- 新規定数 `kDecreaseBeginTime`、`kDecreasePerSec` を追加。
- メンバ変数 `decreaseTimer_` を追加。
  - スコア減少タイミングを管理。
- `currentScore_` の初期化をリファクタリング。

### その他
- バイナリファイルやJSONの変更はなし。