### PR TITLE
feat: プレイヤーの爆発トリガー機能を追加

### DIFF
--- a/app/WinterGame.vcxproj
+++ b/app/WinterGame.vcxproj
@@ -209,6 +209,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="src\entity\player\PlayerInput.h" />
     <ClInclude Include="src\entity\player\PlayerMovement.h" />
     <ClInclude Include="src\logic\event\KillEnemyEvent.h" />
+    <ClInclude Include="src\logic\event\PlayerExplosionEvent.h" />
     <ClInclude Include="src\scene\Edit\EditScene.h" />
     <ClInclude Include="src\scene\GameOverTest\GameOverTestScene.h" />
     <ClInclude Include="src\scene\game\animation\GameClearAnimation.h" />

--- a/app/WinterGame.vcxproj.filters
+++ b/app/WinterGame.vcxproj.filters
@@ -287,6 +287,7 @@
     </ClInclude>
     <ClInclude Include="src\logic\event\KillEnemyEvent.h" />
     <ClInclude Include="src\entity\player\PlayerExplosionTrigger.h" />
+    <ClInclude Include="src\logic\event\PlayerExplosionEvent.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="resources\Json\.engine\config.json">

--- a/app/src/entity/player/Player.cpp
+++ b/app/src/entity/player/Player.cpp
@@ -208,7 +208,7 @@ void Player::ComponentInitialize()
     pMovement_->Initialize(pInput_.get(), &transform_);
     // 爆発トリガー
     pExplosionTrigger_ = std::make_unique<PlayerExplosionTrigger>();
-    pExplosionTrigger_->Initialize();
+    pExplosionTrigger_->Initialize(pInput_.get());
 }
 
 void Player::ImGui()

--- a/app/src/entity/player/PlayerExplosionTrigger.cpp
+++ b/app/src/entity/player/PlayerExplosionTrigger.cpp
@@ -4,9 +4,11 @@
 #include <functional>
 #include <Features/DeltaTimeManager/DeltaTimeManager.h>
 #include <imgui.h>
+#include <logic/event/PlayerExplosionEvent.h>
 
-void PlayerExplosionTrigger::Initialize()
+void PlayerExplosionTrigger::Initialize(PlayerInput* pInput)
 {
+    pInput_ = pInput;
     subscription_ = EventListener::GetInstance()->Subscribe<KillEnemyEvent>(
         std::bind(
             &PlayerExplosionTrigger::OnKillEnemyEvent,
@@ -24,8 +26,10 @@ void PlayerExplosionTrigger::Update()
 
     if (decreaseTimer_->GetNow<float>() > kDecreaseBeginTime)
     {
-        DecreaseScore();
+        this->DecreaseScore();
     }
+
+    this->UpdateTriggerIf();
 }
 
 void PlayerExplosionTrigger::ImGui()
@@ -59,4 +63,20 @@ void PlayerExplosionTrigger::DecreaseScore()
     float dt = DeltaTimeManager::GetInstance()->GetDeltaTime(channel);
     currentScore_ -= kDecreasePerSec * dt;
     if (currentScore_ < 0.0f) currentScore_ = 0.0f;
+}
+
+void PlayerExplosionTrigger::UpdateTriggerIf()
+{
+    if (!pInput_) return;
+    
+    bool doExplosion = pInput_->GetData().isExplosionTriggered;
+    doExplosion &= (currentScore_ >= targetTriggerScore_);
+
+    if (doExplosion)
+    {
+        // トリガー発動
+        currentScore_ = 0.0f;
+        decreaseTimer_->Reset();
+        EventListener::GetInstance()->Publish(PlayerExplosionEvent{});
+    }
 }

--- a/app/src/entity/player/PlayerExplosionTrigger.h
+++ b/app/src/entity/player/PlayerExplosionTrigger.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "PlayerInput.h"
 #include <logic/event/KillEnemyEvent.h>
 #include <Features/TimeMeasurer/TimeMeasurerByDt.h>
 #include <Features/Event/EventSubscription.h>
@@ -11,13 +12,14 @@ public:
     PlayerExplosionTrigger() = default;
     ~PlayerExplosionTrigger() = default;
 
-    void Initialize();
+    void Initialize(PlayerInput* pInput);
     void Update();
     void ImGui();
     void OnKillEnemyEvent(const KillEnemyEvent& payload);
 
 private:
     void DecreaseScore();
+    void UpdateTriggerIf();
 
     static constexpr float kScorePerEnemy = 5.0f;
     static constexpr float kDecreaseBeginTime = 1.0f;
@@ -25,7 +27,8 @@ private:
 
     const float targetTriggerScore_ = 100.0f;
 
-    std::unique_ptr<TimeMeasurerByDt>   decreaseTimer_ = {};
-    std::optional<EventSubscription>    subscription_ = std::nullopt;
-    float                               currentScore_ = 0.0f;
+    PlayerInput*                        pInput_         = nullptr;
+    std::unique_ptr<TimeMeasurerByDt>   decreaseTimer_  = {};
+    std::optional<EventSubscription>    subscription_   = std::nullopt;
+    float                               currentScore_   = 0.0f;
 };

--- a/app/src/entity/player/PlayerInput.cpp
+++ b/app/src/entity/player/PlayerInput.cpp
@@ -27,4 +27,7 @@ void PlayerInput::Update()
     data_.isSlowPressed = pInput_->PushKey(DIK_LSHIFT);
     // スロー(リリース)
     data_.isSlowReleased = preData.isSlowPressed && !data_.isSlowPressed;
+    // 爆発トリガー
+    data_.isExplosionTriggered |= pInput_->TriggerKey(DIK_SPACE);
+    data_.isExplosionTriggered |= pInput_->TriggerMouse(Input::MouseNum::Right);
 }

--- a/app/src/entity/player/PlayerInput.h
+++ b/app/src/entity/player/PlayerInput.h
@@ -7,10 +7,11 @@ class PlayerInput
 public:
     struct Data
     {
-        bool    isSlowPressed   = false;
-        bool    isShotPressed   = false;
-        bool    isSlowTriggered = false;
-        bool    isSlowReleased  = false;
+        bool    isSlowPressed           = false;
+        bool    isShotPressed           = false;
+        bool    isSlowTriggered         = false;
+        bool    isSlowReleased          = false;
+        bool    isExplosionTriggered    = false;
         // 移動方向ベクトル (PlayerInput::Update()で正規化済み)
         Vector3 move = {};
     };

--- a/app/src/logic/event/PlayerExplosionEvent.h
+++ b/app/src/logic/event/PlayerExplosionEvent.h
@@ -1,0 +1,7 @@
+#pragma once
+
+struct PlayerExplosionEvent
+{
+    float explosionPower = 0.0f; // The power of the explosion
+    float explosionRadius = 0.0f; // The radius of the explosion
+};


### PR DESCRIPTION
### 概要
プレイヤーが特定の条件下で爆発を発動できる新機能を追加しました。

### 変更内容

#### `PlayerExplosionEvent.h`
- 新しいヘッダーファイルを追加し、爆発イベントを表現する構造体 `PlayerExplosionEvent` を定義。

#### `WinterGame.vcxproj` / `WinterGame.vcxproj.filters`
- `PlayerExplosionEvent.h` をプロジェクトおよびフィルタに追加。

#### `Player.cpp`
- `Player::ComponentInitialize()` メソッドで、`PlayerExplosionTrigger` の初期化時に `PlayerInput` を渡すよう変更。

#### `PlayerExplosionTrigger.cpp`
- `PlayerExplosionTrigger::Initialize()` メソッドを `PlayerInput*` を引数として受け取るよう変更。
- `PlayerExplosionTrigger::Update()` に `UpdateTriggerIf()` メソッドを追加。
- 新メソッド `UpdateTriggerIf()` を追加し、爆発トリガーの発動条件をチェックして `PlayerExplosionEvent` を発行。

#### `PlayerExplosionTrigger.h`
- `PlayerExplosionTrigger::Initialize()` のシグネチャを変更。
- 新しいプライベートメソッド `UpdateTriggerIf()` を追加。
- クラスメンバーに `PlayerInput* pInput_` を追加。

#### `PlayerInput.cpp`
- `PlayerInput::Update()` メソッドに、スペースキーまたは右クリックで爆発トリガーを発動するロジックを追加。

#### `PlayerInput.h`
- `PlayerInput::Data` 構造体に新しいメンバー `isExplosionTriggered` を追加。

### その他
- JSONやリソースファイルの変更はありません。