### PR TITLE
change: IGameLayerのInitialize引数をOrderedCanvasLayer*に変更

### DIFF
--- a/app/src/core/IGameLayer.h
+++ b/app/src/core/IGameLayer.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <Interfaces/ISceneArgs.h>
-#include <Features/Layer/Layer.h>
+#include <Features/Layer/OrderedCanvasLayer.h>
 
 class IGameLayer
 {
@@ -10,7 +10,7 @@ public:
     /// <summary>
     /// 初期化を行います。
     /// </summary>
-    virtual void Initialize(ISceneArgs* pArgs, Layer* pLayer) = 0;
+    virtual void Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer) = 0;
 
     /// <summary>
     /// 終了処理を行います。

--- a/app/src/scene/game/layer/GameLayer.cpp
+++ b/app/src/scene/game/layer/GameLayer.cpp
@@ -16,7 +16,7 @@
 #include <mathExtension.h>
 
 
-void GameLayer::Initialize(ISceneArgs* pArgs, Layer* pLayer)
+void GameLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
 {
     /// インスタンスの取得
     pDx12_ = std::any_cast<DirectX12*>(pArgs->Get("DirectX12"));

--- a/app/src/scene/game/layer/GameLayer.h
+++ b/app/src/scene/game/layer/GameLayer.h
@@ -16,7 +16,7 @@
 #include <Features/Model/ModelManager.h>
 #include <Features/RandomGenerator/RandomGenerator.h>
 #include <Features/TimeMeasurer/TimeMeasurer.h>
-#include <Features/Layer/Layer.h>
+#include <Features/Layer/OrderedCanvasLayer.h>
 #include <Interfaces/ISceneArgs.h>
 
 // post effects
@@ -54,7 +54,7 @@
 class GameLayer : public IGameLayer
 {
 public:
-    void Initialize(ISceneArgs* pArgs, Layer* pLayer) override;
+    void Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer) override;
     void Finalize() override;
     void Update() override;
     void Draw() override;
@@ -150,7 +150,7 @@ private:
     ModelManager*       pModelManager_      = nullptr;
     LineSystem*         pLineSystem_        = nullptr;
     TextureManager*     pTextureManager_    = nullptr;
-    Layer*              pLayer_             = nullptr;
+    OrderedCanvasLayer* pLayer_             = nullptr;
     GrayscaleOption*    pOptionGrayscale_   = nullptr;
 
     /// [ デバッグ ]

--- a/app/src/scene/game/layer/ResultLayer.cpp
+++ b/app/src/scene/game/layer/ResultLayer.cpp
@@ -2,7 +2,7 @@
 #include <any>
 #include <Core/DirectX12/DirectX12.h>
 
-void ResultLayer::Initialize(ISceneArgs* pArgs, Layer* pLayer)
+void ResultLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
 {
     Canvas::Params canvasParams{};
     canvasParams.name = "ResultCanvas";

--- a/app/src/scene/game/layer/ResultLayer.h
+++ b/app/src/scene/game/layer/ResultLayer.h
@@ -7,7 +7,7 @@
 class ResultLayer : public IGameLayer
 {
 public:
-    void Initialize(ISceneArgs* pArgs, Layer* pLayer) override;
+    void Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer) override;
     void Finalize() override;
     void Update() override;
     void Draw() override;

--- a/app/src/scene/game/layer/TitleLayer.cpp
+++ b/app/src/scene/game/layer/TitleLayer.cpp
@@ -2,7 +2,7 @@
 
 
 
-void TitleLayer::Initialize(ISceneArgs* pArgs, Layer* pLayer)
+void TitleLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
 {
 }
 

--- a/app/src/scene/game/layer/TitleLayer.h
+++ b/app/src/scene/game/layer/TitleLayer.h
@@ -5,7 +5,7 @@
 class TitleLayer : public IGameLayer
 {
 public:
-    void Initialize(ISceneArgs* pArgs, Layer* pLayer) override;
+    void Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer) override;
 
     void Finalize() override;
 

--- a/app/src/ui/gauge/RingGauge.cpp
+++ b/app/src/ui/gauge/RingGauge.cpp
@@ -107,6 +107,7 @@ void RingGauge::InitializeObjects()
     objectRingBackground_->Initialize();
     objectRingBackground_->SetModel(modelRingBackground_.get());
     {
+        // object3dの設定
         auto& option = objectRingBackground_->GetOption();
         option.materialData->color = params_.colorBackground.to_Vector4();
         option.lightingData->enableLighting = false;
@@ -117,6 +118,7 @@ void RingGauge::InitializeObjects()
     objectRingFill_->Initialize();
     objectRingFill_->SetModel(modelRingFill_.get());
     {
+        // object3dの設定
         auto& option = objectRingFill_->GetOption();
         option.materialData->color = params_.colorFill.to_Vector4();
         option.lightingData->enableLighting = false;


### PR DESCRIPTION
## IGameLayer
- Initialize関数の引数型を`Layer*`から`OrderedCanvasLayer*`に変更。

## GameLayer
- Initialize関数のシグネチャを`OrderedCanvasLayer*`対応に修正。
- メンバ変数`pLayer_`の型を`Layer*`から`OrderedCanvasLayer*`に変更。
- 実装ファイル（cpp）も新しい引数型に合わせて修正。

## ResultLayer
- Initialize関数のシグネチャを`OrderedCanvasLayer*`対応に修正。
- 実装ファイル（cpp）も新しい引数型に合わせて修正。

## TitleLayer
- Initialize関数のシグネチャを`OrderedCanvasLayer*`対応に修正。
- 実装ファイル（cpp）も新しい引数型に合わせて修正。

---

※バイナリファイルやjson等の変更はありません。
※サブモジュールの更新内容は本コミットメッセージでは省略しています。