### PR TITLE
change: スロー・爆発操作キーの割り当てを入れ替え

### DIFF
--- a/app/src/entity/player/PlayerInput.cpp
+++ b/app/src/entity/player/PlayerInput.cpp
@@ -22,12 +22,12 @@ void PlayerInput::Update()
     // 射撃
     data_.isShotPressed = pInput_->PushMouse(Input::MouseNum::Left);
     // スロー(トリガー)
-    data_.isSlowTriggered = pInput_->TriggerKey(DIK_LSHIFT);
+    data_.isSlowTriggered = pInput_->TriggerKey(DIK_SPACE);
     // スロー(プレス)
-    data_.isSlowPressed = pInput_->PushKey(DIK_LSHIFT);
+    data_.isSlowPressed = pInput_->PushKey(DIK_SPACE);
     // スロー(リリース)
     data_.isSlowReleased = preData.isSlowPressed && !data_.isSlowPressed;
     // 爆発トリガー
-    data_.isExplosionTriggered |= pInput_->TriggerKey(DIK_SPACE);
+    data_.isExplosionTriggered |= pInput_->TriggerKey(DIK_LSHIFT);
     data_.isExplosionTriggered |= pInput_->TriggerMouse(Input::MouseNum::Right);
 }


### PR DESCRIPTION
---
### PlayerInputクラス

- スロー操作のキー割り当てを「Shiftキー（DIK_LSHIFT）」から「スペースキー（DIK_SPACE）」に変更しました。
    - スローのトリガー判定、プレス判定が対象です。
- 爆発トリガーのキー割り当てを「スペースキー（DIK_SPACE）」から「Shiftキー（DIK_LSHIFT）」に変更しました。
    - 爆発トリガー判定が対象です。

---
※バイナリファイルやjson等の変更はありません。