### PR TITLE
change: ダッシュ色変化の持続時間を0.8秒に変更

### DIFF
--- a/app/src/entity/enemy/rusher/EnemyRusherStateAim.h
+++ b/app/src/entity/enemy/rusher/EnemyRusherStateAim.h
@@ -11,6 +11,6 @@ public:
 
 private:
     static constexpr float kAimDurationSec_ = 1.0f;
-    static constexpr float kDashColorDurationSec_ = 0.5f;
+    static constexpr float kDashColorDurationSec_ = 0.8f;
     float elapsedTimeSec_ = 0.0f;
 };


### PR DESCRIPTION
---

### EnemyRusherStateAim

- 定数 `kDashColorDurationSec_` の値を 0.5秒 から 0.8秒 に変更しました。
- これにより、ダッシュ時の色変化の持続時間が長くなります。