### PR TITLE
feat: EnemyRusher死亡時にSE再生機能を追加

### DIFF
--- a/app/src/entity/enemy/rusher/EnemyRusher.cpp
+++ b/app/src/entity/enemy/rusher/EnemyRusher.cpp
@@ -1,4 +1,5 @@
 #include "EnemyRusher.h"
+
 #include <Features/DeltaTimeManager/DeltaTimeManager.h>
 #include "EnemyRusherStateFollow.h"
 #include "EnemyRusherStateKnockback.h"
@@ -6,10 +7,11 @@
 #include <Features/Collision/Manager/CollisionManager.h>
 #include <functional>
 #include <logic/event/KillEnemyEvent.h>
-#include "nima_engine/src/Features/event/EventListener.h"
+#include <Features/event/EventListener.h>
 #include <logic/event/ParticleEmitEvent.h>
 #include <presentation/ParticleType.h>
-
+#include <config/ResourcePath.h>
+#include <Features/Audio/AudioManager.h>
 
 
 void EnemyRusher::Initialize(bool enableDebugWindow /*= true*/)
@@ -19,6 +21,10 @@ void EnemyRusher::Initialize(bool enableDebugWindow /*= true*/)
 
     this->InitializeComponents();
     this->InitializeState();
+
+    /// オーディオの初期化
+    audioDeath_ = AudioManager::GetInstance()->GetNewAudio("Effect", Path::Audio::kSeEnemyDeath);
+    audioDeath_->SetVolume(0.05f);
 }
 
 void EnemyRusher::Finalize()
@@ -106,6 +112,7 @@ void EnemyRusher::OnCollisionTrigger(const Collider* pOther)
         {
             // 死亡する
             EntityBase::Dead();
+            audioDeath_->Play();
 
             /// あたっている相手に応じてスコアイベントを発行
             if (isPlayerBullet)

--- a/app/src/entity/enemy/rusher/EnemyRusher.h
+++ b/app/src/entity/enemy/rusher/EnemyRusher.h
@@ -13,6 +13,7 @@
 #include "nima_engine/src/Features/Primitive/Sphere.h"
 #include "../../Status/EntityStats.h"
 #include <nima_engine/modules/vectormatrix/math/Color.h>
+#include <Features/Audio/Audio.h>
 
 class EnemyRusher : public EntityBase
 {
@@ -125,6 +126,10 @@ private:
     // 移動コンポーネントを差し替えて使うためのポインタ
     IMovement* pCurrentMovement_ = nullptr;
     
+    /// [ SE ]
+    Audio* audioDeath_ = nullptr;
+
+    /// [ コンポーネント ]
     std::unique_ptr<PhysicsMovement>    pPhysicsMovement_   = nullptr;
     std::unique_ptr<FollowMovement>     pFollowMovement_    = nullptr;
     std::unique_ptr<DashMovementLinear> pDashMovement_      = nullptr;


### PR DESCRIPTION
## EnemyRusher
- 死亡時に効果音(SE)を再生する機能を追加。
- Initialize()でAudioManagerから死亡SEを取得し、音量を0.05fに設定。
- OnCollisionTrigger()でHPが0以下になった際、audioDeath_->Play()でSEを再生。
- audioDeath_メンバ変数とAudio関連ヘッダーを追加。

## その他
- バイナリファイルやjson等の変更はありません。