### PR TITLE
feat: InstancedObject3d用頂点シェーダを新規追加

### DIFF
--- a/app/EngineResources/Shaders/DepthBasedOutline.PS.hlsl
+++ b/app/EngineResources/Shaders/DepthBasedOutline.PS.hlsl
@@ -11,13 +11,13 @@ struct DepthOutlineOption
     float weightMultiply;
 };
 
-struct Material
+struct MaterialForGPU
 {
     float4x4 projectionInverse;
 };
 
 ConstantBuffer<DepthOutlineOption> gOptions : register(b0); // カーネルのサイズを指定する定数バッファ
-ConstantBuffer<Material> gMaterial : register(b1); // マテリアルの定数バッファ
+ConstantBuffer<MaterialForGPU> gMaterial : register(b1); // マテリアルの定数バッファ
 
 struct PixelShaderOutput
 {

--- a/app/EngineResources/Shaders/InstancedObject3d.VS.hlsl
+++ b/app/EngineResources/Shaders/InstancedObject3d.VS.hlsl
@@ -1,0 +1,28 @@
+#include "Object3d.hlsli"
+
+struct InstanceData
+{
+    float4x4 WVP;
+    float4x4 World;
+    float4 color;
+};
+ 
+StructuredBuffer<InstanceData> gInstanceData : register(t0);
+
+struct VertexShaderInput
+{
+    float4 position : POSITION0;
+    float2 texcoord : TEXCOORD0;
+    float3 normal : NORMAL0;
+};
+
+VertexShaderOutput main(VertexShaderInput input, uint instanceId : SV_InstanceID)
+{
+    VertexShaderOutput output;
+    output.position = mul(input.position, gInstanceData[instanceId].WVP);
+    output.texcoord = input.texcoord;
+    output.normal = normalize(mul(input.normal, (float3x3) gInstanceData[instanceId].World));
+    output.worldPosition = mul(input.position, gInstanceData[instanceId].World).xyz;
+    output.color = gInstanceData[instanceId].color;
+    return output;
+}

--- a/app/EngineResources/Shaders/Object3d.PS.hlsl
+++ b/app/EngineResources/Shaders/Object3d.PS.hlsl
@@ -7,24 +7,24 @@ struct Camera
 
 struct Material
 {
-    float4 color;
     float4x4 uvTransform;
     float shininess;
     float environmentCoefficient;
+    float2 tilingMultiply; //!< UVのタイリング係数
 };
 
 struct Lighting
 {
-    int enableLighting;
+    int enableDirectionalLight;
+    int enablePointLight;
     int lightingType;
 };
 
 struct PointLight
 {
-    int enablePointLight; //!< ポイントライトを有効にするか
-    float4 color; //!< ライトの色
-    float3 position; //!< ライトの位置
-    float intensity; //!< 輝度
+    float4  color;              //!< ライトの色
+    float3  position;           //!< ライトの位置
+    float   intensity;          //!< 輝度
 };
 
 struct DirectionalLight
@@ -34,26 +34,20 @@ struct DirectionalLight
     float intensity; //!< 輝度
 };
 
-struct UVTiling
-{
-    float2 tilingMultiply; //!< UVのタイリング係数
-};
-
-ConstantBuffer<Material> gMaterial : register(b0);
-ConstantBuffer<DirectionalLight> gDirectionalLight : register(b1);
-ConstantBuffer<UVTiling> gUVTiling : register(b2);
-ConstantBuffer<Camera> gCamera : register(b3);
-ConstantBuffer<Lighting> gLighting : register(b4);
-ConstantBuffer<PointLight> gPointLight : register(b5);
+ConstantBuffer<Material>            gMaterial           : register(b0);
+ConstantBuffer<DirectionalLight>    gDirectionalLight   : register(b1);
+ConstantBuffer<Camera>              gCamera             : register(b3);
+ConstantBuffer<Lighting>            gLighting           : register(b4);
+ConstantBuffer<PointLight>          gPointLight         : register(b5);
 
 struct PixelShaderOutput
 {
     float4 color : SV_TARGET0;
 };
 
-Texture2D<float4> gTexture : register(t0);
-SamplerState gSampler : register(s0);
+Texture2D<float4>   gTexture            : register(t0);
 TextureCube<float4> gEnvironmentTexture : register(t1);
+SamplerState        gSampler            : register(s0);
 
 [earlydepthstencil]
 PixelShaderOutput main(VertexShaderOutput input)
@@ -63,7 +57,7 @@ PixelShaderOutput main(VertexShaderOutput input)
 
     float4 transformedUV = mul(float4(input.texcoord, 0.0f, 1.0f), gMaterial.uvTransform);
 
-    transformedUV.xy *= gUVTiling.tilingMultiply;
+    transformedUV.xy *= gMaterial.tilingMultiply;
 
     float4 textureColor = gTexture.Sample(gSampler, transformedUV.xy);
     
@@ -73,7 +67,7 @@ PixelShaderOutput main(VertexShaderOutput input)
     float3 reflectedVector = reflect(cameraToPosition, normalize(input.normal));
     float4 environmentColor = gEnvironmentTexture.Sample(gSampler, reflectedVector);
     
-    if (gLighting.enableLighting != 0)
+    if (gLighting.enableDirectionalLight != 0)
     {
         float cos;
         if (gLighting.lightingType == 0)
@@ -92,17 +86,17 @@ PixelShaderOutput main(VertexShaderOutput input)
         float NdotH = dot(normalize(input.normal), halfVector);
         float specularPow = pow(saturate(NdotH), gMaterial.shininess); // 反射強度
         
-        float3 diffuse = gMaterial.color.rgb * textureColor.rgb * gDirectionalLight.color.rgb * cos * gDirectionalLight.intensity;
+        float3 diffuse = input.color.rgb * textureColor.rgb * gDirectionalLight.color.rgb * cos * gDirectionalLight.intensity;
         float3 specular = gDirectionalLight.color.rgb * gDirectionalLight.intensity * specularPow * float3(1.0f, 1.0f, 1.0f);
 
         /// ポイントライト
-        if (gPointLight.enablePointLight == 1)
+        if (gLighting.enablePointLight == 1)
         {
             float distance = length(gPointLight.position - input.worldPosition); // ポイントライトへの距離
             if (distance < 0.1f) distance = 0.1f; // 0除算対策
             float factor = 1.0f / (distance * distance); // 距離の2乗に反比例する
             
-            float3 pointLightDiffuse = gMaterial.color.rgb * textureColor.rgb * gPointLight.color.rgb * saturate(dot(input.normal, pointLightDir)) * gPointLight.intensity * factor;
+            float3 pointLightDiffuse = input.color.rgb * textureColor.rgb * gPointLight.color.rgb * saturate(dot(input.normal, pointLightDir)) * gPointLight.intensity * factor;
             float3 pointLightSpecular = gPointLight.color.rgb * gPointLight.intensity * specularPow * float3(1.0f, 1.0f, 1.0f) * factor;
             
             output.color.rgb = diffuse + specular + pointLightDiffuse + pointLightSpecular;
@@ -111,11 +105,11 @@ PixelShaderOutput main(VertexShaderOutput input)
         {
             output.color.rgb = diffuse + specular;
         }
-        output.color.a = gMaterial.color.a * textureColor.a;
+        output.color.a = input.color.a * textureColor.a;
     }
     else
     {
-        output.color = gMaterial.color * textureColor;
+        output.color = input.color * textureColor;
     }
 
     //if (textureColor.a <= 0.f || output.color.a <= 0.f)

--- a/app/EngineResources/Shaders/Object3d.VS.hlsl
+++ b/app/EngineResources/Shaders/Object3d.VS.hlsl
@@ -6,7 +6,12 @@ struct TransformationMatrix
     float4x4 World;
 };
 
+struct Color {
+    float4 value;
+};
+
 ConstantBuffer<TransformationMatrix> gTransformationMatrix : register(b0);
+ConstantBuffer<Color> gColor : register(b1);
 
 struct VertexShaderInput
 {
@@ -22,5 +27,6 @@ VertexShaderOutput main(VertexShaderInput input)
     output.texcoord = input.texcoord;
     output.normal = normalize(mul(input.normal, (float3x3)gTransformationMatrix.World));
     output.worldPosition = mul(input.position, gTransformationMatrix.World).xyz;
+    output.color = gColor.value;
     return output;
 }

--- a/app/EngineResources/Shaders/Object3d.hlsli
+++ b/app/EngineResources/Shaders/Object3d.hlsli
@@ -4,4 +4,5 @@ struct VertexShaderOutput
     float2 texcoord : TEXCOORD0;
     float3 normal : NORMAL0;
     float3 worldPosition : POSITION0;
+    float4 color : COLOR0;
 };

--- a/app/EngineResources/Shaders/SkinningObject3d.PS.hlsl
+++ b/app/EngineResources/Shaders/SkinningObject3d.PS.hlsl
@@ -5,22 +5,23 @@ struct Camera
     float3 worldPosition;
 };
 
-struct Material
+struct MaterialForGPU
 {
-    float4 color;
     float4x4 uvTransform;
     float shininess;
+    float environmentCoefficient;
+    float2 tilingMultiply; //!< UVのタイリング係数
 };
 
 struct Lighting
 {
-    int enableLighting;
+    int enableDirectionalLight;
+    int enablePointLight;
     int lightingType;
 };
 
 struct PointLight
 {
-    int enablePointLight; //!< ポイントライトを有効にするか
     float4 color; //!< ライトの色
     float3 position; //!< ライトの位置
     float intensity; //!< 輝度
@@ -33,14 +34,8 @@ struct DirectionalLight
     float intensity; //!< 輝度
 };
 
-struct UVTiling
-{
-    float2 tilingMultiply; //!< UVのタイリング係数
-};
-
-ConstantBuffer<Material> gMaterial : register(b0);
+ConstantBuffer<MaterialForGPU> gMaterial : register(b0);
 ConstantBuffer<DirectionalLight> gDirectionalLight : register(b1);
-ConstantBuffer<UVTiling> gUVTiling : register(b2);
 ConstantBuffer<Camera> gCamera : register(b3);
 ConstantBuffer<Lighting> gLighting : register(b4);
 ConstantBuffer<PointLight> gPointLight : register(b5);
@@ -60,14 +55,14 @@ PixelShaderOutput main(VertexShaderOutput input)
 
     float4 transformedUV = mul(float4(input.texcoord, 0.0f, 1.0f), gMaterial.uvTransform);
 
-    transformedUV.xy *= gUVTiling.tilingMultiply;
+    transformedUV.xy *= gMaterial.tilingMultiply;
 
     float4 textureColor = gTexture.Sample(gSampler, transformedUV.xy);
     
     float3 pointLightDir = normalize(gPointLight.position - input.worldPosition);
 
 
-    if (gLighting.enableLighting != 0)
+    if (gLighting.enableDirectionalLight != 0)
     {
         float cos;
         if (gLighting.lightingType == 0)
@@ -86,17 +81,17 @@ PixelShaderOutput main(VertexShaderOutput input)
         float NdotH = dot(normalize(input.normal), halfVector);
         float specularPow = pow(saturate(NdotH), gMaterial.shininess); // 反射強度
         
-        float3 diffuse = gMaterial.color.rgb * textureColor.rgb * gDirectionalLight.color.rgb * cos * gDirectionalLight.intensity;
+        float3 diffuse = input.color.rgb * textureColor.rgb * gDirectionalLight.color.rgb * cos * gDirectionalLight.intensity;
         float3 specular = gDirectionalLight.color.rgb * gDirectionalLight.intensity * specularPow * float3(1.0f, 1.0f, 1.0f);
 
         /// ポイントライト
-        if (gPointLight.enablePointLight == 1)
+        if (gLighting.enablePointLight == 1)
         {
             float distance = length(gPointLight.position - input.worldPosition); // ポイントライトへの距離
             if (distance < 0.1f) distance = 0.1f; // 0除算対策
             float factor = 1.0f / (distance * distance); // 距離の2乗に反比例する
             
-            float3 pointLightDiffuse = gMaterial.color.rgb * textureColor.rgb * gPointLight.color.rgb * saturate(dot(input.normal, pointLightDir)) * gPointLight.intensity * factor;
+            float3 pointLightDiffuse = input.color.rgb * textureColor.rgb * gPointLight.color.rgb * saturate(dot(input.normal, pointLightDir)) * gPointLight.intensity * factor;
             float3 pointLightSpecular = gPointLight.color.rgb * gPointLight.intensity * specularPow * float3(1.0f, 1.0f, 1.0f) * factor;
             
             output.color.rgb = diffuse + specular + pointLightDiffuse + pointLightSpecular;
@@ -105,11 +100,11 @@ PixelShaderOutput main(VertexShaderOutput input)
         {
             output.color.rgb = diffuse + specular;
         }
-        output.color.a = gMaterial.color.a * textureColor.a;
+        output.color.a = input.color.a * textureColor.a;
     }
     else
     {
-        output.color = gMaterial.color * textureColor;
+        output.color = input.color * textureColor;
     }
 
     //if (textureColor.a <= 0.f || output.color.a <= 0.f)

--- a/app/EngineResources/Shaders/SkinningObject3d.VS.hlsl
+++ b/app/EngineResources/Shaders/SkinningObject3d.VS.hlsl
@@ -6,6 +6,10 @@ struct TransformationMatrix
     float4x4 World;
 };
 
+struct Color {
+    float4 value;
+};
+
 struct Vertex
 {
     float4 position;
@@ -14,7 +18,7 @@ struct Vertex
 };
 
 ConstantBuffer<TransformationMatrix> gTransformationMatrix : register(b0);
-
+ConstantBuffer<Color> gColor : register(b1);
 
 struct VertexShaderInput
 {
@@ -32,5 +36,6 @@ VertexShaderOutput main(VertexShaderInput input)
     output.worldPosition = mul(skinned.position, gTransformationMatrix.World).xyz;
     output.texcoord = input.texcoord;
     output.normal = normalize(mul(input.normal, (float3x3)gTransformationMatrix.World));
+    output.color = gColor.value;
     return output;
 }

--- a/app/EngineResources/Shaders/Skybox.PS.hlsl
+++ b/app/EngineResources/Shaders/Skybox.PS.hlsl
@@ -1,11 +1,11 @@
 #include "skybox.hlsli"
 
-struct Material
+struct MaterialForGPU
 {
     float4 color;
 };
 
-ConstantBuffer<Material> gMaterial : register(b0);
+ConstantBuffer<MaterialForGPU> gMaterial : register(b0);
 
 struct PixelShaderOutput
 {

--- a/app/EngineResources/Shaders/Sprite.PS.hlsl
+++ b/app/EngineResources/Shaders/Sprite.PS.hlsl
@@ -1,13 +1,13 @@
 #include "Sprite.hlsli"
 
 
-struct Material
+struct MaterialForGPU
 {
     float4 color;
     float4x4 uvTransform;
 };
 
-ConstantBuffer<Material> gMaterial : register(b0);
+ConstantBuffer<MaterialForGPU> gMaterial : register(b0);
 
 struct PixelShaderOutput
 {

--- a/app/imgui.ini
+++ b/app/imgui.ini
@@ -561,6 +561,11 @@ Pos=60,60
 Size=173,124
 Collapsed=0
 
+[Window][SceneManager##000001B3824BE400]
+Pos=60,60
+Size=717,209
+Collapsed=0
+
 [Table][0x3A809993,2]
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000

--- a/app/imgui.ini
+++ b/app/imgui.ini
@@ -4,8 +4,8 @@ Size=400,400
 Collapsed=0
 
 [Window][Log]
-Pos=354,704
-Size=1246,196
+Pos=25,25
+Size=7,22
 Collapsed=0
 DockId=0x00000030,0
 
@@ -54,14 +54,14 @@ Size=32,32
 Collapsed=0
 
 [Window][Viewport]
-Pos=0,0
-Size=32,32
+Pos=26,17
+Size=6,22
 Collapsed=0
 DockId=0x0000002D,0
 
 [Window][DebugInfoBar]
 Pos=0,0
-Size=1600,37
+Size=32,15
 Collapsed=0
 DockId=0x00000004,0
 
@@ -83,20 +83,20 @@ Collapsed=0
 DockId=0x0000002D,0
 
 [Window][Components]
-Pos=0,39
-Size=148,861
+Pos=0,17
+Size=15,22
 Collapsed=0
 DockId=0x00000001,0
 
 [Window][Debug]
-Pos=150,39
-Size=594,663
+Pos=17,17
+Size=7,22
 Collapsed=0
 DockId=0x0000002B,0
 
 [Window][EventTimer]
-Pos=150,704
-Size=202,196
+Pos=17,25
+Size=6,22
 Collapsed=0
 DockId=0x0000002F,0
 
@@ -531,6 +531,36 @@ Size=4,22
 Collapsed=0
 DockId=0x00000009,0
 
+[Window][PlayerConstant##000001C08B5DE360]
+Pos=60,60
+Size=179,124
+Collapsed=0
+
+[Window][unnamed##0000027A0488F990]
+Pos=60,60
+Size=179,124
+Collapsed=0
+
+[Window][Spark##0000027A04890290]
+Pos=60,60
+Size=173,124
+Collapsed=0
+
+[Window][EnemyDeath##0000027A048919A0]
+Pos=60,60
+Size=173,124
+Collapsed=0
+
+[Window][unnamed##0000027A04891E20]
+Pos=60,60
+Size=179,124
+Collapsed=0
+
+[Window][EnemyDeath2##0000027A04890C20]
+Pos=60,60
+Size=173,124
+Collapsed=0
+
 [Table][0x3A809993,2]
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
@@ -964,6 +994,30 @@ Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
 [Table][0x8D80107A,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x4D7799CA,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x1FA79CF3,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x425B715B,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0xA9023FD5,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0xCDC90B3A,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0xD83BCB7C,2]
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 

--- a/app/resources/Json/ParticleEmitter/Scene_GameOver_Explosion.json
+++ b/app/resources/Json/ParticleEmitter/Scene_GameOver_Explosion.json
@@ -30,9 +30,10 @@
         "enableCollisionFloor": true,
         "enableRandomEmit": true,
         "enableRandomRotation": false,
-        "enableRandomScale": true,
+        "enableRandomScale": false,
         "enableRandomVelocity": true,
         "enableScaleTransition": true,
+        "enableSmoothNoise": false,
         "velocityDistribution": 1
     },
     "name": "Spark",
@@ -47,7 +48,8 @@
             "x": 0.0,
             "y": 0.0,
             "z": 0.0
-        }
+        },
+        "smoothNoisePower": 0.0
     },
     "ranges": {
         "color": {
@@ -95,8 +97,8 @@
                 "z": 1.0
             },
             "start": {
-                "x": 0.25,
-                "y": 0.25,
+                "x": 0.5,
+                "y": 0.5,
                 "z": 1.0
             }
         },

--- a/app/src/entity/EntityBase.h
+++ b/app/src/entity/EntityBase.h
@@ -2,7 +2,7 @@
 
 #include <Vector3.h>
 #include <Features/GameEye/GameEye.h>
-#include <Features/Lighting/PointLight/PointLight.h>
+#include <Features/Lighting/PointLight.h>
 #include <Entity/Status/EntityStats.h>
 #include <DebugTools/DebugEntry/DebugEntry.h>
 #include <Interfaces/IEntityStats.h>

--- a/app/src/entity/enemy/EnemyFactory.cpp
+++ b/app/src/entity/enemy/EnemyFactory.cpp
@@ -18,7 +18,7 @@ std::unique_ptr<EntityBase> EnemyFactory::Create(const EnemyType enemyType)
 std::unique_ptr<EntityBase> EnemyFactory::CreateNormal() const
 {
     EnemyNormalInitParams param;
-    param.pModelSelfBody = context_.pModelSelfBody;
+    param.pObject3dInstanced = context_.pObject3dInstanced;
     param.position = context_.position;
     param.pDirLight = context_.pDirLight;
     param.pTargetPosition = context_.pTargetPosition;
@@ -28,7 +28,7 @@ std::unique_ptr<EntityBase> EnemyFactory::CreateNormal() const
 std::unique_ptr<EntityBase> EnemyFactory::CreateRusher() const
 {
     EnemyRusherInitParams param;
-    param.pModelSelfBody = context_.pModelSelfBody;
+    param.pObject3dInstanced = context_.pObject3dInstanced;
     param.position = context_.position;
     param.pDirLight = context_.pDirLight;
     param.pTargetPosition = context_.pTargetPosition;

--- a/app/src/entity/enemy/EnemyInitParams.h
+++ b/app/src/entity/enemy/EnemyInitParams.h
@@ -1,12 +1,13 @@
 #pragma once
-#include <Common/structs.h>
 #include <Features/Model/IModel.h>
 #include <Vector3.h>
+#include <Features/Lighting/DirectionalLight.h>
+#include <drawable/object3d/Object3dInstanced.h>
 
 struct EnemyContext
 {
+    Object3dInstanced*  pObject3dInstanced  = nullptr;
     DirectionalLight*   pDirLight           = nullptr;
-    IModel*             pModelSelfBody      = nullptr;      // 本体モデル
     Vector3             position            = {};           // 初期位置
     const Vector3*      pTargetPosition     = nullptr;      // 追尾対象位置
 };
@@ -14,7 +15,7 @@ struct EnemyContext
 struct EnemyRusherInitParams
 {
     DirectionalLight*   pDirLight           = nullptr;
-    IModel*             pModelSelfBody      = nullptr;      // 本体モデル
+    Object3dInstanced*  pObject3dInstanced  = nullptr;
     Vector3             position            = {};           // 初期位置
     const Vector3*      pTargetPosition     = nullptr;      // 追尾対象位置
 };
@@ -22,7 +23,7 @@ struct EnemyRusherInitParams
 struct EnemyNormalInitParams
 {
     DirectionalLight*   pDirLight           = nullptr;
-    IModel*             pModelSelfBody      = nullptr;      // 本体モデル
+    Object3dInstanced*  pObject3dInstanced  = nullptr;
     Vector3             position            = {};           // 初期位置
     const Vector3*      pTargetPosition     = nullptr;      // 追尾対象位置
 };

--- a/app/src/entity/enemy/EnemyNormal.cpp
+++ b/app/src/entity/enemy/EnemyNormal.cpp
@@ -9,7 +9,6 @@
 
 EnemyNormal::EnemyNormal(const EnemyNormalInitParams& param)
 {
-    pModelSelfBody_ = param.pModelSelfBody->Cloned();
     params_ = param;
 }
 
@@ -29,9 +28,6 @@ void EnemyNormal::Initialize(bool enableDebugWindow)
     pStats_ = std::make_unique<EntityStats>();
     pStats_->Initialize(1.0f, 10.0f, 10.0f);
 
-    // オブジェクトの初期化
-    this->InitializeObjects();
-
     // コライダーの初期化
     this->InitializeCollider();
 
@@ -49,8 +45,6 @@ void EnemyNormal::Finalize()
     /// コライダーの削除
     pCollisionManager_->UnregisterCollider(pCollider_.get());
 
-    pObjectSelfBody_->Finalize();
-
     EventListener* pEventListener = EventListener::GetInstance();
 
     ParticleEmitEvent emitEvent;
@@ -63,10 +57,11 @@ void EnemyNormal::Finalize()
 
     if (params_.pDirLight) 
     {
-        params_.pDirLight->intensity += 0.5f;
-        if (params_.pDirLight->intensity > 8.0f)
+        auto& data = params_.pDirLight->GetData();
+        data.intensity += 0.5f;
+        if (data.intensity > 8.0f)
         {
-            params_.pDirLight->intensity = 8.0f;
+            data.intensity = 8.0f;
         }
     }
 }
@@ -76,9 +71,6 @@ void EnemyNormal::Update()
     const auto  dtChannel = static_cast<uint32_t>(DeltaTimeChannelReserved::Game);
     const float deltaTime = pDeltaTimeManager_->GetDeltaTime(dtChannel);
 
-    /// オブジェクトの更新
-    this->UpdateObjects();
-
     /// コライダーの更新
     this->UpdateCollider();
 
@@ -86,11 +78,17 @@ void EnemyNormal::Update()
     pMovement_->ApplyFriction(kFriction_);
     pMovement_->Update(transform_, deltaTime);
     pFocusOrientation_->Update(transform_, deltaTime);
+
+    Object3dInstanceData drawData;
+    drawData.scale = transform_.scale;
+    drawData.rotate = transform_.rotate;
+    drawData.translate = transform_.translate;
+    drawData.color = kColorBody_;
+    params_.pObject3dInstanced->emplace_back(drawData);
 }
 
 void EnemyNormal::Draw1F()
 {
-    if (pObjectSelfBody_) pObjectSelfBody_->Draw1F();
     if (isDrawCollisionArea_) sphereLine_.Draw1F();
 }
 
@@ -101,26 +99,7 @@ void EnemyNormal::InitializeComponents()
     pFocusOrientation_ = std::make_unique<FocusOrientation>();
     pFocusOrientation_->SetTargetPosition(params_.pTargetPosition);
     pFocusOrientation_->SetRotateRatio(0.95f);
-}
-
-void EnemyNormal::InitializeObjects()
-{
-    if (pModelSelfBody_ == nullptr)
-    {
-        Logger::GetInstance()->LogError(__FILE__, __FUNCTION__, "pModelSelfBody_ がnullptrです");
-    }
-
-    /// オブジェクトの初期化
-    pObjectSelfBody_ = std::make_unique<Object3d>();
-    pObjectSelfBody_->Initialize(false);
-    pObjectSelfBody_->SetName("enemy");
-    pObjectSelfBody_->SetTranslate(Vector3(0, 0.5f, 0));
-    pObjectSelfBody_->SetRotate(Vector3(0, 0, 0));
-    pObjectSelfBody_->SetModel(pModelSelfBody_.get());
-    auto& option = pObjectSelfBody_->GetOption();
-    option.materialData->environmentCoefficient = 0.0f;
-    option.materialData->color = Vector4(1.0f, 0.0f, 0.0f, 1.0f);
-    option.lightingData->enableLighting = false;
+    transform_.scale = Vector3(1.0f, 1.0f, 1.0f);
 }
 
 void EnemyNormal::InitializeCollider()
@@ -149,13 +128,6 @@ void EnemyNormal::UpdateCollider()
     sphereLine_.Update();
 
     pCollider_->SetShapeData(&sphere_);
-}
-
-void EnemyNormal::UpdateObjects()
-{
-    pObjectSelfBody_->SetTranslate(transform_.translate);
-    pObjectSelfBody_->SetRotate(transform_.rotate);
-    pObjectSelfBody_->Update();
 }
 
 void EnemyNormal::OnCollision(const Collider* other)

--- a/app/src/entity/enemy/EnemyNormal.h
+++ b/app/src/entity/enemy/EnemyNormal.h
@@ -62,11 +62,6 @@ private:
     void InitializeComponents();
 
     /// <summary>
-    /// モデルや表示オブジェクトを初期化します。
-    /// </summary>
-    void InitializeObjects();
-
-    /// <summary>
     /// コライダーを初期化します。
     /// </summary>
     void InitializeCollider();
@@ -75,11 +70,6 @@ private:
     /// 当たり判定の更新を行います。
     /// </summary>
     void UpdateCollider();
-
-    /// <summary>
-    /// 表示オブジェクトの更新を行います。
-    /// </summary>
-    void UpdateObjects();
 
     /// <summary>
     /// 物理衝突時に呼ばれます。
@@ -99,14 +89,13 @@ private:
     static constexpr float      kFriction_          = 0.95f;
     static constexpr float      kReflectionPower_   = 15.0f;
     static constexpr float      kCameraShakePower_  = 0.1f;
+    static constexpr Vector4    kColorBody_         = Vector4(1.0f, 0.0f, 0.0f, 1.0f);
 
     /// [ 初期化パラメータ ]
     EnemyNormalInitParams params_ = {};
 
     /// [ コンポーネント ]
     EulerTransform                          transform_          = {};
-    std::unique_ptr<Object3d>               pObjectSelfBody_    = {};
-    std::unique_ptr<IModel>                 pModelSelfBody_     = nullptr;
     std::unique_ptr<TimeMeasurer>           pTimeMeasurer_      = {};
     std::unique_ptr<EntityStats>            pStats_             = nullptr;
     std::unique_ptr<FollowMovement>         pMovement_          = nullptr;

--- a/app/src/entity/enemy/rusher/EnemyRusher.cpp
+++ b/app/src/entity/enemy/rusher/EnemyRusher.cpp
@@ -43,14 +43,13 @@ void EnemyRusher::Finalize()
 
     CollisionManager::GetInstance()->UnregisterCollider(pCollider_.get());
 
-    pObjectSelfBody_->Finalize();
-
     if (params_.pDirLight)
     {
-        params_.pDirLight->intensity += 0.5f;
-        if (params_.pDirLight->intensity > 8.0f)
+        auto& data = params_.pDirLight->GetData();
+        data.intensity += 0.5f;
+        if (data.intensity > 8.0f)
         {
-            params_.pDirLight->intensity = 8.0f;
+            data.intensity = 8.0f;
         }
     }
 }
@@ -74,21 +73,20 @@ void EnemyRusher::Update()
         pCurrentMovement_->Update(transform_, deltaTime);
     }
 
-    /// オブジェクト更新
-    if (pObjectSelfBody_)
-    {
-        pObjectSelfBody_->SetRotate(transform_.rotate);
-        pObjectSelfBody_->SetTranslate(transform_.translate);
-        pObjectSelfBody_->Update();
-    }
-
     /// コライダー更新
     pSphere_->center_ = transform_.translate;
+
+    /// 描画データを積む
+    Object3dInstanceData drawData = {};
+    drawData.scale = transform_.scale;
+    drawData.rotate = transform_.rotate;
+    drawData.translate = transform_.translate;
+    drawData.color = color_;
+    params_.pObject3dInstanced->emplace_back(drawData);
 }
 
 void EnemyRusher::Draw1F()
 {
-    if (pObjectSelfBody_) pObjectSelfBody_->Draw1F();
 }
 
 void EnemyRusher::ImGui()
@@ -215,8 +213,7 @@ void EnemyRusher::DisableMovement()
 
 void EnemyRusher::ChangeColor(const Vector4& color)
 {
-    if (!pObjectSelfBody_) return;
-    pObjectSelfBody_->GetOption().materialData->color = color;
+    color_ = color;
 }
 
 bool EnemyRusher::IsCloseToTarget(float thresholdDistance) const
@@ -271,7 +268,7 @@ void EnemyRusher::InitializeState()
 void EnemyRusher::InitializeComponents()
 {
     this->InitializeTransform();
-    this->InitializeBody();
+    color_ = kColorDefault_.to_Vector4();
     this->InitializeMovement();
     this->InitializeFocusOrientation();
     this->InitializeStats();
@@ -287,23 +284,9 @@ void EnemyRusher::InitializeTransform()
     transform_.translate.z = params_.position.z;
 }
 
-void EnemyRusher::InitializeBody()
-{
-    if (!params_.pModelSelfBody) return;
-    pObjectSelfBody_ = std::make_unique<Object3d>();
-    pObjectSelfBody_->Initialize(false);
-    pObjectSelfBody_->SetModel(params_.pModelSelfBody);
-    pObjectSelfBody_->SetScale(transform_.scale);
-    auto& option = pObjectSelfBody_->GetOption();
-    option.materialData->color = kColorDefault_.to_Vector4();
-    option.lightingData->enableLighting = false;
-    option.materialData->environmentCoefficient = 0.0f;
-}
-
 void EnemyRusher::InitializeCollider(EntityStats* pStats)
 {
     auto pCollisionManager = CollisionManager::GetInstance();
-    if (!params_.pModelSelfBody) return;
 
     /// コライダー形状の初期化
     pSphere_ = std::make_unique<Sphere>();

--- a/app/src/entity/enemy/rusher/EnemyRusher.h
+++ b/app/src/entity/enemy/rusher/EnemyRusher.h
@@ -39,10 +39,9 @@ public:
     /// </summary>
     void ChangeState(std::unique_ptr<EnemyRusherState> newState);
 
-public:
     /// [ 行動インターフェース ]
 
-    /// <summary>ターゲットに向かって注視します。</summary>
+    /// ターゲットに向かって注視します。
     void FocusOnTarget(float deltaTime);
 
     /// ターゲットに向かってダッシュ移動を開始します。
@@ -88,7 +87,6 @@ private:
     void InitializeComponents();
     // コンポーネントの初期化
     void InitializeTransform();
-    void InitializeBody();
     void InitializeMovement();
     void InitializeFocusOrientation();
     void InitializeStats();
@@ -103,8 +101,8 @@ private:
 
     EnemyRusherInitParams           params_;
     EulerTransform                  transform_          = {};
+    Vector4                         color_              = {};
     std::unique_ptr<Collider>       pCollider_          = nullptr;
-    std::unique_ptr<Object3d>       pObjectSelfBody_    = {};
     std::unique_ptr<Sphere>         pSphere_            = {};
     std::unique_ptr<EntityStats>    pStats_             = nullptr;
 
@@ -112,8 +110,8 @@ private:
     IMovement* pCurrentMovement_ = nullptr;
     
     /// [ SE ]
-    Audio* audioDeath_ = nullptr;
-    Audio* audioAim_ = nullptr;
+    Audio*  audioDeath_  = nullptr;
+    Audio*  audioAim_    = nullptr;
 
     /// [ コンポーネント ]
     std::unique_ptr<PhysicsMovement>    pPhysicsMovement_   = nullptr;

--- a/app/src/entity/explosion/PlayerExplosion.cpp
+++ b/app/src/entity/explosion/PlayerExplosion.cpp
@@ -77,8 +77,8 @@ void PlayerExplosion::InitializeRing()
     pObjectRing_->SetName("Player Explosion Object3d");
     pObjectRing_->SetModel(pModelRing_.get());
     auto& option = pObjectRing_->GetOption();
-    option.materialData->color = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
-    option.lightingData->enableLighting = false;
+    *option.colorData = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
+    option.lightSettingData->enableDirectionalLight = false;
     option.materialData->environmentCoefficient = 0.0f;
 }
 
@@ -119,7 +119,7 @@ void PlayerExplosion::UpdateOpacity()
     const float opacity = 1.0f - Math::Easing::EaseInCubic(t);
 
     auto& option = pObjectRing_->GetOption();
-    option.materialData->color.w = opacity;
+    option.colorData->w = opacity;
 }
 
 void PlayerExplosion::UpdateCollider()

--- a/app/src/entity/player/GameOverAnimation.cpp
+++ b/app/src/entity/player/GameOverAnimation.cpp
@@ -44,7 +44,7 @@ void GameOverAnimation::Play()
     timer_.Start();
     original_.playerScale = initParams_.pPlayer->GetObject3d()->GetScale();
     original_.cameraPosition = initParams_.pGameEye->GetTransform().translate;
-    original_.pointLightIntensity = initParams_.pPointLight->GetIntensity();
+    original_.pointLightIntensity = initParams_.pPointLight->GetData().intensity;
     pEmitter_->Emit();
     pEmitter_->Emit();
 }
@@ -58,7 +58,7 @@ void GameOverAnimation::Reset()
     auto obj = initParams_.pPlayer->GetObject3d();
     obj->SetScale(original_.playerScale);
     initParams_.pGameEye->SetTranslate(original_.cameraPosition);
-    initParams_.pPointLight->GetIntensity() = original_.pointLightIntensity;
+    initParams_.pPointLight->GetData().intensity = original_.pointLightIntensity;
 }
 
 void GameOverAnimation::ShakeCameraUpdate()
@@ -97,11 +97,11 @@ void GameOverAnimation::LightIntensityUpdate()
     if (timer_.GetNow<float>() > stateDurations_.at(State::SmallScaling))
     {
         // 時間経過したら終了
-        initParams_.pPointLight->GetIntensity() = 0.0f;
+        initParams_.pPointLight->GetData().intensity = 0.0f;
         return;
     }
 
     float t = timer_.GetNow<float>() / stateDurations_.at(State::SmallScaling);
     float easedT = Math::Easing::EaseInOutQuad(t);
-    initParams_.pPointLight->GetIntensity() = std::lerp(original_.pointLightIntensity, 0.0f, easedT);
+    initParams_.pPointLight->GetData().intensity = std::lerp(original_.pointLightIntensity, 0.0f, easedT);
 }

--- a/app/src/entity/player/GameOverAnimation.h
+++ b/app/src/entity/player/GameOverAnimation.h
@@ -5,7 +5,7 @@
 #include <Features/GameEye/GameEye.h>
 #include <unordered_map>
 #include <Features/TimeMeasurer/TimeMeasurer.h>
-#include <Features/Lighting/PointLight/PointLight.h>
+#include <Features/Lighting/PointLight.h>
 
 class GameOverAnimation
 {

--- a/app/src/entity/player/Player.cpp
+++ b/app/src/entity/player/Player.cpp
@@ -1,8 +1,9 @@
 #include "Player.h"
 
-#include <imgui.h>
 #include <Features/Model/ObjModel.h>
 #include <config/ResourcePath.h>
+#include <imgui.h>
+
 
 Player::Player(const Params& params) : pModelManager_(params.pModelManager)
 {
@@ -29,9 +30,6 @@ void Player::Initialize(bool enableDebugWindow)
     pTimerShot_ = std::make_unique<TimeMeasurer>();
     pTimerShot_->Start();
 
-    /// [ パーティクルエミッターの初期化 ]
-    this->ParticleEmittersInitialize();
-
     // オブジェクトの初期化
     this->ObjectsInitialize();
 
@@ -44,20 +42,22 @@ void Player::Initialize(bool enableDebugWindow)
     // オーディオハンドルの初期化
     this->AudioHandleInitialize();
 
-    if (params_.pDirLight) pObject_->SetDirectionalLight(params_.pDirLight);
-    if (params_.pPointLight) pObject_->SetPointLight(params_.pPointLight);
+    if (params_.pDirLight)
+        pObject_->SetDirectionalLight(params_.pDirLight);
+    if (params_.pPointLight)
+        pObject_->SetPointLight(params_.pPointLight);
 }
 
 void Player::Finalize()
 {
     pObject_->Finalize();
     pCollisionManager_->UnregisterCollider(pCollider_.get());
-    if (pEmitterConstant_) pEmitterConstant_->Finalize();
 }
 
 void Player::Update()
 {
-    const auto  kDeltaTimeChannel = static_cast<uint32_t>(DeltaTimeChannelReserved::Game);
+    const auto kDeltaTimeChannel =
+        static_cast<uint32_t>(DeltaTimeChannelReserved::Game);
     const float kDeltaTime = pDeltaTimeManager_->GetDeltaTime(kDeltaTimeChannel);
 
     isShot_ = false;
@@ -84,19 +84,8 @@ void Player::Update()
     }
 
     // AABBリミッターの更新 (ここで座標補正が入る)
-    if (pAABBLimitter_) pAABBLimitter_->Update(transform_);
-
-    // パーティクルエミッターの更新 (動いている or 動きが無効化されている場合にパーティクルをエミット)
-    if (pEmitterConstant_)
-    {
-        if ((pMovement_->IsMove(0.2f)) || flags_ & static_cast<uint32_t>(Flags::DisableMovement))
-        {
-
-            pEmitterConstant_->SetPosition(transform_.translate);
-            pEmitterConstant_->Emit();
-        }
-        pEmitterConstant_->Update();
-    }
+    if (pAABBLimitter_)
+        pAABBLimitter_->Update(transform_);
 
     pExplosionTrigger_->Update();
 
@@ -116,7 +105,6 @@ void Player::Draw1F()
 {
     // オブジェクトの描画
     pObject_->Draw1F();
-    if (pEmitterConstant_) pEmitterConstant_->Draw1F();
 }
 
 void Player::ObjectsInitialize()
@@ -132,7 +120,9 @@ void Player::ObjectsInitialize()
     pObject_->SetModel(pModelSelfBody_.get());
     auto& option = pObject_->GetOption();
     option.materialData->environmentCoefficient = 0.0f;
-    option.materialData->color = Vector4(0.0f, 1.0f, 0.0f, 1.0f);
+    *option.colorData = Vector4(0.0f, 1.0f, 0.0f, 1.0f);
+    option.lightSettingData->enableDirectionalLight = true;
+    option.lightSettingData->enablePointLight = true;
 }
 
 void Player::ColliderInitialize()
@@ -144,29 +134,20 @@ void Player::ColliderInitialize()
     pCollider_->SetOwner(this);
     pCollider_->SetShape(Shape::OBB);
     pCollider_->SetMask(pCollisionManager_->GetNewMask("player"));
-    pCollider_->SetOnCollision(std::bind(&Player::OnCollision, this, std::placeholders::_1));
-    pCollider_->SetOnCollisionTrigger(std::bind(&Player::OnCollisionTrigger, this, std::placeholders::_1));
+    pCollider_->SetOnCollision(
+        std::bind(&Player::OnCollision, this, std::placeholders::_1));
+    pCollider_->SetOnCollisionTrigger(
+        std::bind(&Player::OnCollisionTrigger, this, std::placeholders::_1));
     pCollider_->SetOwnerTransform(&transform_);
     pCollider_->SetEntityStats(pStats_.get());
     // コライダーの登録
     pCollisionManager_->RegisterCollider(pCollider_.get());
 }
 
-void Player::ParticleEmittersInitialize()
-{
-    if (!params_.particle) return;
-    ParticleEmitter::Params emitterParams = {};
-    emitterParams.particle = params_.particle;
-    emitterParams.jsonPath = Path::ParticleEmitter::kPlayerConstantTrail;
-    pEmitterConstant_ = std::make_unique<ParticleEmitter>();
-    pEmitterConstant_->Initialize(emitterParams);
-    pEmitterConstant_->EnableManualMode();
-    pEmitterConstant_->SetEnableBillboard(true);
-}
-
 void Player::UpdateInputCommands()
 {
-    if (this->IsAlive() == false) return;
+    if (this->IsAlive() == false)
+        return;
 
     const auto& inputData = pInput_->GetData();
 
@@ -193,22 +174,26 @@ void Player::UpdateInputCommands()
 
 void Player::AudioHandleInitialize()
 {
-    pAudioShot_ = pAudioManager_->GetNewAudio("Effect", Path::Audio::kSePlayerShoot);
+    pAudioShot_ =
+        pAudioManager_->GetNewAudio("Effect", Path::Audio::kSePlayerShoot);
     pAudioShot_->SetVolume(0.1f);
-    pAudioDeath_ = pAudioManager_->GetNewAudio("Effect", Path::Audio::kSePlayerDeath);
+    pAudioDeath_ =
+        pAudioManager_->GetNewAudio("Effect", Path::Audio::kSePlayerDeath);
     pAudioDeath_->SetVolume(0.15f);
-    pAudioSlowOn_ = pAudioManager_->GetNewAudio("Effect", Path::Audio::kSePlayerSlowOn);
+    pAudioSlowOn_ =
+        pAudioManager_->GetNewAudio("Effect", Path::Audio::kSePlayerSlowOn);
     pAudioSlowOn_->SetVolume(0.1f);
-    pAudioSlowOff_ = pAudioManager_->GetNewAudio("Effect", Path::Audio::kSePlayerSlowOff);
+    pAudioSlowOff_ =
+        pAudioManager_->GetNewAudio("Effect", Path::Audio::kSePlayerSlowOff);
     pAudioSlowOff_->SetVolume(0.1f);
 }
 
 void Player::ComponentInitialize()
 {
     // トランスフォーム
-    transform_.scale        = Vector3(1.0f, 1.0f, 1.0f);
-    transform_.rotate       = Vector3(0.0f, 0.0f, 0.0f);
-    transform_.translate    = Vector3(0, 0.5f, 0);
+    transform_.scale = Vector3(1.0f, 1.0f, 1.0f);
+    transform_.rotate = Vector3(0.0f, 0.0f, 0.0f);
+    transform_.translate = Vector3(0, 0.5f, 0);
     // ステータス
     pStats_ = std::make_unique<EntityStats>();
     pStats_->Initialize(100.0f, 0.0f, 20.0f);
@@ -237,10 +222,10 @@ void Player::ComponentInitialize()
 
 void Player::ImGui()
 {
-#ifdef _DEBUG
+    #ifdef _DEBUG
     EntityBase::ImGui();
     pExplosionTrigger_->ImGui();
-#endif
+    #endif
 }
 
 void Player::DisableMovement()
@@ -260,7 +245,8 @@ void Player::OnCollisionTrigger(const Collider* other)
         auto pOtherEntityStats = other->GetEntityStats();
         assert(pOtherEntityStats);
         pStats_->OnCollision(pOtherEntityStats);
-        if (params_.pDirLight) params_.pDirLight->intensity -= kLightIntensityDecreaseAmount_;
+        if (params_.pDirLight)
+            params_.pDirLight->GetData().intensity -= kLightIntensityDecreaseAmount_;
         EntityBase::ShakeCamera(kGameEyeShakePowerWhenDamage_);
         if (pStats_->GetHp() <= 0.0f)
         {
@@ -277,7 +263,8 @@ void Player::OnCollision(const Collider* other)
 
     if (other->GetColliderID() == "enemy")
     {
-        assert(other->GetOwnerTransform() && "衝突相手のTransformが設定されていません。");
+        assert(other->GetOwnerTransform() &&
+            "衝突相手のTransformが設定されていません。");
         /// 反発を速度に適用
         Vector3 otherPos = other->GetOwnerTransform()->translate;
         otherPos.y = transform_.translate.y; // Y軸は無視する

--- a/app/src/entity/player/Player.h
+++ b/app/src/entity/player/Player.h
@@ -18,7 +18,7 @@
 #include "PlayerExplosionTrigger.h"
 #include <Math/Transform.h>
 #include <entity/status/EntityStats.h>
-#include <Features/Lighting/PointLight/PointLight.h>
+#include <Features/Lighting/PointLight.h>
 #include <Common/structs.h>
 #include <Features/Primitive/AABB.h>
 #include <component/MovementLimitterAABB.h>
@@ -33,7 +33,6 @@ class Player : public EntityBase
 public:
     struct Params
     {
-        Particle*           particle        = nullptr;
         ModelManager*       pModelManager   = nullptr;
         DirectionalLight*   pDirLight       = nullptr;
         PointLight*         pPointLight     = nullptr;
@@ -117,11 +116,6 @@ private:
     void ColliderInitialize();
 
     /// <summary>
-    /// パーティクルエミッターの初期化を行います。
-    /// </summary>
-    void ParticleEmittersInitialize();
-
-    /// <summary>
     /// 入力状態から移動や射撃などのコマンドを更新します。
     /// </summary>
     void UpdateInputCommands();
@@ -161,9 +155,6 @@ private:
 
     /// コライダー用
     OBB obb_ = {};
-
-    /// [ パーティクルエミッター ]
-    std::unique_ptr<ParticleEmitter>        pEmitterConstant_   = nullptr;    // 常時発生エミッター
 
     /// [ オーディオ ]
     Audio*  pAudioShot_     = nullptr;

--- a/app/src/logic/timer/InGameCountDown.cpp
+++ b/app/src/logic/timer/InGameCountDown.cpp
@@ -70,6 +70,12 @@ void InGameCountDown::Start()
     }
 }
 
+void InGameCountDown::Pause()
+{
+    if (pTimer_) pTimer_->Stop();
+    isStart_ = false;
+}
+
 void InGameCountDown::Initialize(bool _useSystemClock, double _gameDuration)
 {
     gameDuration_ = _gameDuration;

--- a/app/src/logic/timer/InGameCountDown.h
+++ b/app/src/logic/timer/InGameCountDown.h
@@ -44,6 +44,11 @@ public:
     void Start();
 
     /// <summary>
+    /// タイマーを一時停止します。
+    /// </summary>
+    void Pause();
+
+    /// <summary>
     /// タイマーをリセットします。
     /// </summary>
     void Reset();
@@ -51,7 +56,7 @@ public:
 public: /// Getter
     bool IsEnd() const { return isEnd_; }
     double GetNowTime() const { return nowTime_; }
-
+    bool IsRunning() const { return isStart_; }
 
 
 public: /// Setter

--- a/app/src/scene/edit/EditScene.cpp
+++ b/app/src/scene/edit/EditScene.cpp
@@ -19,6 +19,22 @@ void EditScene::Initialize()
     /// [ デバッグウィンドウを登録 ]
     pDebugEntry_ = std::make_unique<DebugEntry<EditScene>>("Scene", "EditScene", this);
 
+    /// [ ライトの初期化 ]
+    pDirectionalLight_ = std::make_unique<DirectionalLight>(pDx12_->GetDevice());
+    pDirectionalLight_->Initialize();
+    auto& data = pDirectionalLight_->GetData();
+    data.color = Vector4(0.065f, 0.058f, 0.058f, 1.0f);
+    data.direction = Vector3(0.0f, -1.0f, -0.0f);
+    data.intensity = 3.0f;
+    pPointLight_ = std::make_unique<PointLight>(pDx12_->GetDevice());
+    pPointLight_->Initialize();
+
+    /// [ デフォルトで使用する光源を登録 ]
+    Object3dSystem::GetInstance()->SetDirectionalLight(pDirectionalLight_.get());
+    Object3dSystem::GetInstance()->SetPointLight(pPointLight_.get());
+    Object3dInstancedSystem::GetInstance()->SetDirectionalLight(pDirectionalLight_.get());
+    Object3dInstancedSystem::GetInstance()->SetPointLight(pPointLight_.get());
+
     /// [ キャンバスの初期化 ]
     this->InitializeCanvas();
 
@@ -26,18 +42,12 @@ void EditScene::Initialize()
     pGameEye_ = std::make_unique<FreeLookEye>();
     pGameEye_->SetTranslate(Vector3(0, 65.0f, 0));
     pGameEye_->SetRotate(Vector3(1.57f, 0, 0));
+
+    Object3dInstancedSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
     Object3dSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
     SpriteSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
-    ParticleSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
     LineSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
-
-    /// [ 平行光源の初期化 ]
-    pDirectionalLight_ = std::make_unique<DirectionalLight>(pDx12_->GetDevice());
-    pDirectionalLight_->Initialize();
-    auto& data = pDirectionalLight_->GetData();
-    data.color = Vector4(0.065f, 0.058f, 0.058f, 1.0f);
-    data.direction = Vector3(0.0f, -1.0f, -0.0f);
-    data.intensity = 3.0f;
+    ParticleSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
 
     Object3dSystem::GetInstance()->SetDirectionalLight(pDirectionalLight_.get());
 

--- a/app/src/scene/edit/EditScene.cpp
+++ b/app/src/scene/edit/EditScene.cpp
@@ -31,6 +31,16 @@ void EditScene::Initialize()
     ParticleSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
     LineSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
 
+    /// [ 平行光源の初期化 ]
+    pDirectionalLight_ = std::make_unique<DirectionalLight>(pDx12_->GetDevice());
+    pDirectionalLight_->Initialize();
+    auto& data = pDirectionalLight_->GetData();
+    data.color = Vector4(0.065f, 0.058f, 0.058f, 1.0f);
+    data.direction = Vector3(0.0f, -1.0f, -0.0f);
+    data.intensity = 3.0f;
+
+    Object3dSystem::GetInstance()->SetDirectionalLight(pDirectionalLight_.get());
+
     /// [ パーティクルの初期化 ]
     this->InitializeParticle();
 
@@ -47,11 +57,6 @@ void EditScene::Initialize()
 
     /// [ 数値表示の初期化 ]
     this->InitializeNumeric();
-
-    /// [ 平行光源の初期化 ]
-    directionalLight_.color = Vector4(0.065f, 0.058f, 0.058f, 1.0f);
-    directionalLight_.direction = Vector3(0.0f, -1.0f, -0.0f);
-    directionalLight_.intensity = 3.0f;
 
     /// [ エンティティの初期化 ]
     pTime_ = std::make_unique<TimeMeasurer>();
@@ -85,7 +90,7 @@ void EditScene::Finalize()
 
 void EditScene::Update()
 {
-    directionalLight_.intensity = std::lerp(directionalLight_.intensity, 6.0f, 0.1f);
+    pDirectionalLight_->GetData().intensity = std::lerp(pDirectionalLight_->GetData().intensity, 6.0f, 0.1f);
 
     pGameEye_->Update();
     pGrid_->Update();
@@ -183,9 +188,8 @@ void EditScene::InitializeEnemy(Player* pPlayer)
 void EditScene::InitializePlayer()
 {
     Player::Params params = {};
-    params.particle = nullptr;
     params.pModelManager = pModelManager_;
-    params.pDirLight = &directionalLight_;
+    params.pDirLight = pDirectionalLight_.get();
     params.pPointLight = nullptr;
     params.pMovableBounds = nullptr;
     pPlayer_ = std::make_unique<Player>(params);
@@ -195,9 +199,8 @@ void EditScene::InitializePlayer()
 void EditScene::InitializeObject3d()
 {
     pGrid_ = presets::grid::Create(pModelManager_->Load("Grid_v3/Grid_v3.obj"));
-    pGrid_->GetOption().lightingData->enableLighting = true;
-    pGrid_->SetDirectionalLight(&directionalLight_);
-    pGrid_->GetOption().tilingData->tilingMultiply = Vector2(10.0f, 10.0f);
+    pGrid_->GetOption().lightSettingData->enableDirectionalLight= true;
+    pGrid_->GetOption().materialData->tilingMultiply = Vector2(10.0f, 10.0f);
 
     RingModel::Params ringParams = {};
     ringParams.pDx12 = pDx12_;

--- a/app/src/scene/edit/EditScene.h
+++ b/app/src/scene/edit/EditScene.h
@@ -11,12 +11,12 @@
 #include <drawable/particle/Emitter/ParticleEmitter.h>
 #include <DebugTools/DebugEntry/DebugEntry.h>
 #include <Features/TimeMeasurer/TimeMeasurer.h>
-#include <Common/structs.h>
 #include <ui/gauge/RingGauge.h>
 #include <drawable/font/NumericView.h>
 #include <entity/enemy/Rusher/EnemyRusher.h>
 #include <entity/player/Player.h>
 #include <entity/enemy/EnemyNormal.h>
+#include <Features/Lighting/DirectionalLight.h>
 
 class EditScene : public SceneBase
 {
@@ -61,11 +61,11 @@ private:
     std::unique_ptr<RingGauge>              pRing_              = nullptr;
     std::unique_ptr<GameEye>                pGameEye_           = nullptr;
     std::unique_ptr<ParticleEmitter>        pParticleEmitter_   = nullptr;
-    std::unique_ptr<EnemyNormal>                  pEnemyNormal_       = nullptr;
+    std::unique_ptr<EnemyNormal>            pEnemyNormal_       = nullptr;
     std::unique_ptr<EnemyRusher>            pEnemyRusher_       = nullptr;
     std::unique_ptr<NumericView>            pNumeric_           = nullptr;
     std::unique_ptr<Player>                 pPlayer_            = nullptr;
-    DirectionalLight                        directionalLight_   = {};
+    std::unique_ptr<DirectionalLight>       pDirectionalLight_  = nullptr;
 
     bool                                    isKillEnemy_        = false;
 

--- a/app/src/scene/edit/EditScene.h
+++ b/app/src/scene/edit/EditScene.h
@@ -17,6 +17,7 @@
 #include <entity/player/Player.h>
 #include <entity/enemy/EnemyNormal.h>
 #include <Features/Lighting/DirectionalLight.h>
+#include <Features/Lighting/PointLight.h>
 
 class EditScene : public SceneBase
 {
@@ -66,6 +67,7 @@ private:
     std::unique_ptr<NumericView>            pNumeric_           = nullptr;
     std::unique_ptr<Player>                 pPlayer_            = nullptr;
     std::unique_ptr<DirectionalLight>       pDirectionalLight_  = nullptr;
+    std::unique_ptr<PointLight>             pPointLight_        = nullptr;
 
     bool                                    isKillEnemy_        = false;
 

--- a/app/src/scene/game/GameScene.cpp
+++ b/app/src/scene/game/GameScene.cpp
@@ -27,8 +27,8 @@ void GameScene::Initialize()
     /// [ デフォルトで使用する光源を登録 ]
     Object3dSystem::GetInstance()->SetDirectionalLight(pDirectionalLight_.get());
     Object3dSystem::GetInstance()->SetPointLight(pPointLight_.get());
-    Object3dInstancedSystem::GetInstance()->SetDefaultLight(pDirectionalLight_.get());
-    Object3dInstancedSystem::GetInstance()->SetDefaultLight(pPointLight_.get());
+    Object3dInstancedSystem::GetInstance()->SetDirectionalLight(pDirectionalLight_.get());
+    Object3dInstancedSystem::GetInstance()->SetPointLight(pPointLight_.get());
 
     /// [ シーンからレイヤーに渡したいデータはここでSceneArgsに追加 ]
     pArgs_->Set("DirectionalLight", pDirectionalLight_.get());

--- a/app/src/scene/game/GameScene.cpp
+++ b/app/src/scene/game/GameScene.cpp
@@ -16,6 +16,23 @@ void GameScene::Initialize()
             std::placeholders::_1
         )
     );
+   
+    /// [ ライトの初期化 ]
+    DirectX12* pDx12 = std::any_cast<DirectX12*>(pArgs_->Get("DirectX12"));
+    pDirectionalLight_ = std::make_unique<DirectionalLight>(pDx12->GetDevice());
+    pDirectionalLight_->Initialize();
+    pPointLight_ = std::make_unique<PointLight>(pDx12->GetDevice());
+    pPointLight_->Initialize();
+
+    /// [ デフォルトで使用する光源を登録 ]
+    Object3dSystem::GetInstance()->SetDirectionalLight(pDirectionalLight_.get());
+    Object3dSystem::GetInstance()->SetPointLight(pPointLight_.get());
+    Object3dInstancedSystem::GetInstance()->SetDefaultLight(pDirectionalLight_.get());
+    Object3dInstancedSystem::GetInstance()->SetDefaultLight(pPointLight_.get());
+
+    /// [ シーンからレイヤーに渡したいデータはここでSceneArgsに追加 ]
+    pArgs_->Set("DirectionalLight", pDirectionalLight_.get());
+    pArgs_->Set("PointLight", pPointLight_.get());
 
     /// [ 各レイヤーの初期化 ]
     if (!pPauseLayer_) pPauseLayer_ = std::make_unique<PauseLayer>();
@@ -23,6 +40,7 @@ void GameScene::Initialize()
     if (!pGameLayer_) pGameLayer_ = std::make_unique<GameLayer>();
     pGameLayer_->Initialize(pArgs_, pLayer_);
 
+    /// [ ポーズ用のブラーエフェクトの初期化 ]
     auto effect = pGameLayer_->GetOverallCanvas()->GetPostEffectExecutor().AddEffect(PostEffectClassName::SeparatedGaussianFilter);
     pGaussianFilter_ = static_cast<SeparatedGaussianFilter*>(effect);
     {
@@ -50,8 +68,11 @@ void GameScene::Update()
     if (pInput_->TriggerKey(DIK_ESCAPE)) this->TogglePauseMenu();
 
     if (!isPauseMenuActive_) pGameLayer_->Update();
-    
     pPauseLayer_->Update();
+
+    /// [ ライトの更新 ]
+    pDirectionalLight_->Update();
+    pPointLight_->Update();
 
     /// [ BGMのフェードアウト ]
     if (isChangingScene_)

--- a/app/src/scene/game/GameScene.h
+++ b/app/src/scene/game/GameScene.h
@@ -14,6 +14,8 @@
 #include <Effects/PostEffects/SeparatedGaussianFilter/SeparatedGaussianFilter.h>
 #include <optional>
 #include <memory>
+#include <Features/Lighting/DirectionalLight.h>
+#include <Features/Lighting/PointLight.h>
 
 /// <summary>
 /// ゲームシーン
@@ -66,12 +68,14 @@ private:
     static constexpr inline float kPauseBlurSigmaLerpFactorDecrease_ = 0.2f;
     static constexpr inline float kPauseBlurSigmaMax_ = 30.0f;
 
-    std::unique_ptr<GameLayer>  pGameLayer_         = nullptr;
-    std::unique_ptr<PauseLayer> pPauseLayer_        = nullptr;
-    Audio*                      pBGM_               = nullptr;  // !< BGMポインタ
-    bool                        isPauseMenuActive_  = false;
-    bool                        isChangingScene_    = false;
-    SeparatedGaussianFilter*    pGaussianFilter_    = nullptr;  // !< ガウシアンフィルタ (ポーズ用)
+    std::unique_ptr<GameLayer>          pGameLayer_         = nullptr;
+    std::unique_ptr<PauseLayer>         pPauseLayer_        = nullptr;
+    std::unique_ptr<DirectionalLight>   pDirectionalLight_  = nullptr;
+    std::unique_ptr<PointLight>         pPointLight_        = nullptr;
+    Audio*                              pBGM_               = nullptr;  // !< BGMポインタ
+    bool                                isPauseMenuActive_  = false;
+    bool                                isChangingScene_    = false;
+    SeparatedGaussianFilter*            pGaussianFilter_    = nullptr;  // !< ガウシアンフィルタ (ポーズ用)
 
     std::optional<EventSubscription> subscriptionPauseMenuToggle_ = std::nullopt;
 

--- a/app/src/scene/game/animation/GameClearAnimation.cpp
+++ b/app/src/scene/game/animation/GameClearAnimation.cpp
@@ -72,7 +72,7 @@ void GameClearAnimation::Play()
     timer_.Start();
     original_.playerScale = initParams_.pPlayer->GetObject3d()->GetScale();
     original_.cameraPosition = initParams_.pGameEye->GetTransform().translate;
-    original_.pointLightIntensity = initParams_.pPointLight->GetIntensity();
+    original_.pointLightIntensity = initParams_.pPointLight->GetData().intensity;
     original_.playerPosition = initParams_.pPlayer->GetObject3d()->GetTranslate();
     original_.cameraRotate = initParams_.pGameEye->GetTransform().rotate;
     original_.score = initParams_.pScoreCalculator->GetScore();
@@ -89,7 +89,7 @@ void GameClearAnimation::Reset()
     auto obj = initParams_.pPlayer->GetObject3d();
     obj->SetScale(original_.playerScale);
     initParams_.pGameEye->SetTranslate(original_.cameraPosition);
-    initParams_.pPointLight->GetIntensity() = original_.pointLightIntensity;
+    initParams_.pPointLight->GetData().intensity = original_.pointLightIntensity;
 }
 
 void GameClearAnimation::ShakeCameraUpdate()
@@ -125,16 +125,18 @@ void GameClearAnimation::CameraApproach()
 
 void GameClearAnimation::LightIntensityUpdate()
 {
+    auto& data = initParams_.pPointLight->GetData();
+
     if (timer_.GetNow<float>() > stateDurations_.at(State::plIntensity))
     {
         // 時間経過したら終了
-        initParams_.pPointLight->GetIntensity() = 5.0f;
+        data.intensity= 5.0f;
         return;
     }
 
     float t = timer_.GetNow<float>() / stateDurations_.at(State::plIntensity);
     float easedT = Math::Easing::EaseInQuad(t);
-    initParams_.pPointLight->GetIntensity() = std::lerp(original_.pointLightIntensity, 5.0f, easedT);
+    data.intensity = std::lerp(original_.pointLightIntensity, 5.0f, easedT);
 }
 
 void GameClearAnimation::SpriteClearUpdate()

--- a/app/src/scene/game/animation/GameClearAnimation.h
+++ b/app/src/scene/game/animation/GameClearAnimation.h
@@ -5,7 +5,7 @@
 #include <Features/GameEye/GameEye.h>
 #include <unordered_map>
 #include <Features/TimeMeasurer/TimeMeasurer.h>
-#include <Features/Lighting/PointLight/PointLight.h>
+#include <Features/Lighting/PointLight.h>
 #include <drawable/sprite/Sprite.h>
 #include <logic/score/ScoreCalculator.h>
 

--- a/app/src/scene/game/layer/GameLayer.cpp
+++ b/app/src/scene/game/layer/GameLayer.cpp
@@ -23,24 +23,25 @@ using namespace Math::Viewport::Unit;
 void GameLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
 {
     /// [ インスタンスの取得 ]
+    pLayer_ = pLayer;
     pDx12_ = std::any_cast<DirectX12*>(pArgs->Get("DirectX12"));
     pDeltaTimeManager_ = DeltaTimeManager::GetInstance();
     randomGenerator_ = RandomGenerator::GetInstance();
     pTextureManager_ = TextureManager::GetInstance();
     pModelManager_ = std::any_cast<ModelManager*>(pArgs->Get("ModelManager"));
     pLineSystem_ = std::any_cast<LineSystem*>(pArgs->Get("LineSystem"));
-    pLayer_ = pLayer;
+    pDirectionalLight_ = std::any_cast<DirectionalLight*>(pArgs->Get("DirectionalLight"));
+    pPointLight_ = std::any_cast<PointLight*>(pArgs->Get("PointLight"));
 
     /// [ デバッグエントリの初期化 ]
     pDebugEntry_ = std::make_unique<DebugEntry<GameLayer>>("Scene", "GameLayer", this);
 
     /// [ グリッドの初期化 ]
     pGrid_ = presets::grid::Create(pModelManager_->Load("Grid_v3/Grid_v3.obj"));
-    pGrid_->GetOption().lightingData->enableLighting = true;
-    pGrid_->SetPointLight(&pointLight_);
-    pGrid_->SetDirectionalLight(&directionalLight_);
+    pGrid_->GetOption().lightSettingData->enablePointLight = true;
+    pGrid_->GetOption().lightSettingData->enableDirectionalLight = true;
     pGrid_->SetScale(Vector3(0.5f, 30.0f, 0.5f));
-    pGrid_->GetOption().tilingData->tilingMultiply = Vector2(10.0f, 10.0f);
+    pGrid_->GetOption().materialData->tilingMultiply = Vector2(10.0f, 10.0f);
 
     /// [ ゲームアイの初期化 ]
     pGameEye_ = std::make_unique<GameEye>();
@@ -49,21 +50,23 @@ void GameLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
     pGameEye_->SetName("main");
 
     /// [ ゲームアイをセット ]
+    Object3dInstancedSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
     Object3dSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
     SpriteSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
     LineSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
     ParticleSystem::GetInstance()->SetGlobalEye(pGameEye_.get());
 
     /// [ 平行光源の初期化 ]
-    directionalLight_.color = Vector4(0.065f, 0.058f, 0.058f, 1.0f);
-    directionalLight_.direction = Vector3(0.0f, -1.0f, -0.0f);
-    directionalLight_.intensity = 1.0f;
+    auto& dirLightData = pDirectionalLight_->GetData();
+    dirLightData.color = Vector4(0.065f, 0.058f, 0.058f, 1.0f);
+    dirLightData.direction = Vector3(0.0f, -1.0f, -0.0f);
+    dirLightData.intensity = 1.0f;
 
     /// [ ポイントライトの初期化 ]
-    pointLight_.IsEnable() = true;
-    pointLight_.GetColor() = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
-    pointLight_.GetIntensity() = 7.5f;
-    pointLight_.GetPosition() = Vector3(0.0f, 0.0f, 2.0f);
+    auto& pointLightData = pPointLight_->GetData();
+    pointLightData.color = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
+    pointLightData.intensity = 7.5f;
+    pointLightData.position = Vector3(0.0f, 0.0f, 2.0f);
 
     /// [ パーティクルの初期化 ]
     this->ParticlesInitialize();
@@ -75,17 +78,16 @@ void GameLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
         playableArea_.SetMinMax(min, max);
     }
 
-    /// [ 座標変換の初期化 ]
+    /// [ 座標変換の初期化 ]6
     screenToWorld_ = std::make_unique<ScreenToWorld>();
     screenToWorld_->Initialize();
     screenToWorld_->SetGameEye(pGameEye_.get());
 
     /// [ プレイヤーの初期化 ]
     Player::Params playerParams = {};
-    playerParams.particle = particles_[static_cast<size_t>(ParticleID::PlayerConstant)];
     playerParams.pModelManager = pModelManager_;
-    playerParams.pDirLight = &directionalLight_;
-    playerParams.pPointLight = &pointLight_;
+    playerParams.pDirLight = pDirectionalLight_;
+    playerParams.pPointLight = pPointLight_;
     playerParams.pMovableBounds = &playableArea_;
     playerParams.pCursorPosition = &screenToWorld_->GetWorldPoint();
     pPlayer_ = std::make_unique<Player>(playerParams);
@@ -95,17 +97,25 @@ void GameLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
     pPlayerUI3d_ = std::make_unique<PlayerUI3d>();
     pPlayerUI3d_->Initialize(pDx12_);
 
+    pObject3dEnemy_ = std::make_unique<Object3dInstanced>();
+    pObject3dEnemy_->Initialize();
+    pObject3dEnemy_->SetModel(pModelManager_->Load("Cube/Cube.obj"));
+    pObject3dEnemy_->GetOption().pMaterialData->environmentCoefficient = 0.0f;
+    pObject3dEnemy_->GetOption().pLightSettingData->enableDirectionalLight = false;
+    pObject3dEnemy_->GetOption().pLightSettingData->enablePointLight = false;
+
     /// [ 敵リポジトリの初期化 ]
     pEnemyRepository_ = std::make_unique<EnemyRepository>();
 
     /// [ 敵ファクトリの初期化 ]
     pEnemyFactory_ = std::make_unique<EnemyFactory>();
     EnemyContext enemyCtx = {};
-    enemyCtx.pDirLight = &directionalLight_;
-    enemyCtx.pModelSelfBody = pModelManager_->Load("Cube/Cube.obj");
+    enemyCtx.pDirLight = pDirectionalLight_;
+    enemyCtx.pObject3dInstanced = pObject3dEnemy_.get();
     enemyCtx.pTargetPosition = &pPlayer_->GetTransform().translate;
     pEnemyFactory_->SetContext(enemyCtx);
 
+    
     /// [ 敵生成システムの初期化 ]
     pEnemyPopSystem_ = std::make_unique<EnemySpawner>();
     pEnemyPopSystem_->Initialize(pEnemyRepository_.get(), pEnemyFactory_.get());
@@ -172,7 +182,7 @@ void GameLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
         {
             .pGameEye = pGameEye_.get(),
             .pPlayer = pPlayer_.get(),
-            .pPointLight = &pointLight_,
+            .pPointLight = pPointLight_,
             .pParticle = particles_[static_cast<size_t>(ParticleID::PlayerDeath)]
         }
     );
@@ -182,7 +192,7 @@ void GameLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
         {
             .pGameEye = pGameEye_.get(),
             .pPlayer = pPlayer_.get(),
-            .pPointLight = &pointLight_,
+            .pPointLight = pPointLight_,
             .pParticle = particles_[static_cast<size_t>(ParticleID::PlayerDeath)],
             .pSpriteClear = spriteClear_.get(),
             .pSpriteSpace = spriteSpace_.get(),
@@ -250,7 +260,8 @@ void GameLayer::Update()
     /// [ ディレクショナルライトを毎フレーム目標値に近づける ]
     if (!isEnding_)
     {
-        directionalLight_.intensity = std::lerp(directionalLight_.intensity, kDirectionalLightTargetIntensity, 0.0125f);
+        auto& dirLightData = pDirectionalLight_->GetData();
+        dirLightData.intensity = std::lerp(dirLightData.intensity, kDirectionalLightTargetIntensity, 0.0125f);
     }
 
     /// [ プレイヤーの更新 ]
@@ -284,7 +295,9 @@ void GameLayer::Update()
     this->CreateEnemy();
 
     /// [ 敵の更新 ]
+    pObject3dEnemy_->clear();
     pEnemyRepository_->Update();
+    pObject3dEnemy_->Update();
 
     /// [ プレイヤー弾の生成 ]
     if (pPlayer_->IsShot())
@@ -307,7 +320,7 @@ void GameLayer::Update()
     /// [ ゲーム開始時のフラッシュ演出 ]
     if (pStartCountDown_->GetState() == CountDown::State::Start && !isGameStartFlashed_)
     {
-        directionalLight_.intensity = kTargetDirectionalLightFlashIntensity_;
+        pDirectionalLight_->GetData().intensity = kTargetDirectionalLightFlashIntensity_;
         isGameStartFlashed_ = true;
     }
 
@@ -320,7 +333,7 @@ void GameLayer::Update()
 
     /// [ ポイントライトの更新 ]
     {
-        auto& position = pointLight_.GetPosition();
+        auto& position = pPointLight_->GetData().position;
         position = pPlayer_->GetTransform().translate;
         position.y = 5.0f;
     }
@@ -391,6 +404,7 @@ void GameLayer::Draw()
 
         /// [ 敵の描画 ]
         pEnemyRepository_->Draw1F();
+        pObject3dEnemy_->Draw1F();
 
         for (auto& bullet : playerBullets_)
         {
@@ -459,6 +473,16 @@ void GameLayer::Preload(const PreloadContext& ctx, TaskExecutor& executor)
 void GameLayer::ImGui()
 {
     #ifdef _DEBUG
+
+    if (ImGui::CollapsingHeader("InGame"))
+    {
+        bool isRunning = ingameTimer_->IsRunning();
+        if (ImGui::Checkbox("GameTimer", &isRunning))
+        {
+            if (isRunning) ingameTimer_->Start();
+            else ingameTimer_->Pause();
+        }
+    }
 
     #endif // _DEBUG
 }

--- a/app/src/scene/game/layer/GameLayer.cpp
+++ b/app/src/scene/game/layer/GameLayer.cpp
@@ -78,7 +78,7 @@ void GameLayer::Initialize(ISceneArgs* pArgs, OrderedCanvasLayer* pLayer)
         playableArea_.SetMinMax(min, max);
     }
 
-    /// [ 座標変換の初期化 ]6
+    /// [ 座標変換の初期化 ]
     screenToWorld_ = std::make_unique<ScreenToWorld>();
     screenToWorld_->Initialize();
     screenToWorld_->SetGameEye(pGameEye_.get());

--- a/app/src/scene/game/layer/GameLayer.h
+++ b/app/src/scene/game/layer/GameLayer.h
@@ -10,10 +10,12 @@
 #include <Features/DeltaTimeManager/DeltaTimeManager.h>
 #include <Features/GameEye/GameEye.h>
 #include <Features/Layer/Canvas.h>
-#include <Features/Lighting/PointLight/PointLight.h>
+#include <Features/Lighting/PointLight.h>
+#include <Features/Lighting/DirectionalLight.h>
 #include <drawable/line/Line.h>
 #include <drawable/line/LineSystem.h>
 #include <drawable/object3d/Object3d.h>
+#include <drawable/object3d/Object3dInstanced.h>
 #include <drawable/particle/Particle.h>
 #include <drawable/particle/Emitter/ParticleEmitter.h>
 #include <drawable/particle/emitter/ParticleEmitterGroup.h>
@@ -132,6 +134,7 @@ private:
     std::unique_ptr<EnemyRepository>                pEnemyRepository_       = {};       // !< 敵リポジトリ
     std::unique_ptr<EnemySpawner>                   pEnemyPopSystem_        = {};       // !< 敵生成システム
     std::unique_ptr<EnemyFactory>                   pEnemyFactory_          = {};       // !< 敵生成ファクトリ
+    std::unique_ptr<Object3dInstanced>              pObject3dEnemy_         = {};       // !< 敵用インスタンスObject3d
 
     std::unique_ptr<Object3d>                       pGrid_                  = {};       // !< グリッド
     std::unique_ptr<GameEye>                        pGameEye_               = {};       // !< ゲームアイ
@@ -142,7 +145,7 @@ private:
     std::unique_ptr<ScoreCalculator>                scoreCalculator_        = {};       // !< スコア計算機
 
     /// UI
-    std::unique_ptr<InGameCountDown>                    ingameTimer_            = {};       // !< ゲームタイマー
+    std::unique_ptr<InGameCountDown>                ingameTimer_            = {};       // !< ゲームタイマー
     std::unique_ptr<InputGuide>                     inputGuide_             = {};       // !< 入力ガイド
     std::unique_ptr<Sprite>                         spriteClear_            = {};       // !< クリアスプライト
     std::unique_ptr<Sprite>                         spriteSpace_            = {};       // !< クリアスプライト
@@ -155,8 +158,6 @@ private:
     std::unique_ptr<RadialBeat>                     pRadialBeat_            = nullptr;  // !< 放射状ブラービート
 
     PlayerBulletGenerator                           playerBulletGenerator_  = {};       // !< プレイヤー弾生成システム
-    DirectionalLight                                directionalLight_       = {};       // !< ディレクショナルライト
-    PointLight                                      pointLight_             = {};       // !< ポイントライト
     std::unique_ptr<CountDown>                      pStartCountDown_        = {};       // !< カウントダウン
     TimeMeasurer                                    timer_                  = {};       // !< タイマー
     double                                          countDownOffset_        = 2.0;      // !< カウントダウンのオフセット
@@ -183,6 +184,8 @@ private:
     TextureManager*     pTextureManager_    = nullptr;
     OrderedCanvasLayer* pLayer_             = nullptr;
     GrayscaleOption*    pOptionGrayscale_   = nullptr;
+    DirectionalLight*   pDirectionalLight_  = nullptr;
+    PointLight*         pPointLight_        = nullptr;
 
     /// [ デバッグ ]
     bool isDisplayColliderEnemy_        = false;

--- a/app/src/ui/gauge/RingGauge.cpp
+++ b/app/src/ui/gauge/RingGauge.cpp
@@ -34,12 +34,12 @@ void RingGauge::Update()
     if (params_.colorTarget.has_value() && rawValue_ >= 1.0f)
     {
         auto& option = objectRingFill_->GetOption();
-        option.materialData->color = params_.colorTarget->to_Vector4();
+        *option.colorData = params_.colorTarget->to_Vector4();
     }
     else // 元の色に戻す
     {
         auto& option = objectRingFill_->GetOption();
-        option.materialData->color = params_.colorFill.to_Vector4();
+        *option.colorData = params_.colorFill.to_Vector4();
     }
 
     objectRingBackground_->Update();
@@ -111,8 +111,8 @@ void RingGauge::InitializeObjects()
     {
         // object3dの設定
         auto& option = objectRingBackground_->GetOption();
-        option.materialData->color = params_.colorBackground.to_Vector4();
-        option.lightingData->enableLighting = false;
+        *option.colorData = params_.colorBackground.to_Vector4();
+        option.lightSettingData->enableDirectionalLight = false;
         option.materialData->environmentCoefficient = 0.0f;
     }
 
@@ -122,8 +122,8 @@ void RingGauge::InitializeObjects()
     {
         // object3dの設定
         auto& option = objectRingFill_->GetOption();
-        option.materialData->color = params_.colorFill.to_Vector4();
-        option.lightingData->enableLighting = false;
+        *option.colorData = params_.colorFill.to_Vector4();
+        option.lightSettingData->enableDirectionalLight = false;
         option.materialData->environmentCoefficient = 0.0f;
     }
 


### PR DESCRIPTION
## InstancedObject3d

- インスタンシング描画に対応した頂点シェーダ `InstancedObject3d.VS.hlsl` を新規追加。
    - `Object3d.hlsli` をインクルードし、共通の出力構造体 `VertexShaderOutput` を利用。
    - インスタンスごとの変換行列（WVP, World）と色（color）を持つ `InstanceData` 構造体を定義。
    - `StructuredBuffer<InstanceData> gInstanceData` を t0 レジスタにバインドし、SV_InstanceID で各インスタンスのデータを参照。
    - 頂点ごとにインスタンス固有の変換・色を適用して出力。
- これにより、`Object3dInstanced` などで大量オブジェクトの効率的なインスタンシング描画が可能となり、パフォーマンス向上が期待できる。

---

※バイナリ・json等の変更はありません。